### PR TITLE
Add logic to SET enable_domain_typmod guc for domains having typmod enabled

### DIFF
--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -868,13 +868,7 @@ DefineDomain(CreateDomainStmt *stmt)
 	/* Domains never accept typmods, so no typmodin/typmodout needed */
 
 	/* Only allow typmods if GUC is set, used by babelfishpg_tsql extension */
-	if (enable_domain_typmod ||
-		(strcmp(get_namespace_name(domainNamespace), "sys") == 0 &&
-		 (strcmp(domainName, "nvarchar") == 0 ||
-		  strcmp(domainName, "nchar") == 0 ||
-		  strcmp(domainName, "varbinary") == 0 ||
-		  strcmp(domainName, "binary") == 0 ||
-		  strcmp(domainName, "decimal") == 0)))
+	if (enable_domain_typmod)
 	{
 		typmodinOid = baseType->typmodin;
 		typmodoutOid = baseType->typmodout;

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -868,7 +868,13 @@ DefineDomain(CreateDomainStmt *stmt)
 	/* Domains never accept typmods, so no typmodin/typmodout needed */
 
 	/* Only allow typmods if GUC is set, used by babelfishpg_tsql extension */
-	if (enable_domain_typmod)
+	if (enable_domain_typmod ||
+		(strcmp(get_namespace_name(domainNamespace), "sys") == 0 &&
+		 (strcmp(domainName, "nvarchar") == 0 ||
+		  strcmp(domainName, "nchar") == 0 ||
+		  strcmp(domainName, "varbinary") == 0 ||
+		  strcmp(domainName, "binary") == 0 ||
+		  strcmp(domainName, "decimal") == 0)))
 	{
 		typmodinOid = baseType->typmodin;
 		typmodoutOid = baseType->typmodout;

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -11277,6 +11277,7 @@ dumpDomain(Archive *fout, const TypeInfo *tyinfo)
 	char	   *typdefault;
 	Oid			typcollation;
 	bool		typdefault_is_literal = false;
+	bool		typsupporttypmod = false;
 
 	/* Fetch domain specific details */
 	if (fout->remoteVersion >= 90100)
@@ -11286,6 +11287,8 @@ dumpDomain(Archive *fout, const TypeInfo *tyinfo)
 						  "pg_catalog.format_type(t.typbasetype, t.typtypmod) AS typdefn, "
 						  "pg_catalog.pg_get_expr(t.typdefaultbin, 'pg_catalog.pg_type'::pg_catalog.regclass) AS typdefaultbin, "
 						  "t.typdefault, "
+						  "CASE WHEN t.typmodin <> 0::pg_catalog.regproc "
+						  "THEN TRUE ELSE FALSE END AS typsupporttypmod, "
 						  "CASE WHEN t.typcollation <> u.typcollation "
 						  "THEN t.typcollation ELSE 0 END AS typcollation "
 						  "FROM pg_catalog.pg_type t "
@@ -11298,7 +11301,10 @@ dumpDomain(Archive *fout, const TypeInfo *tyinfo)
 		appendPQExpBuffer(query, "SELECT typnotnull, "
 						  "pg_catalog.format_type(typbasetype, typtypmod) AS typdefn, "
 						  "pg_catalog.pg_get_expr(typdefaultbin, 'pg_catalog.pg_type'::pg_catalog.regclass) AS typdefaultbin, "
-						  "typdefault, 0 AS typcollation "
+						  "typdefault, "
+						  "CASE WHEN typmodin <> 0::pg_catalog.regproc "
+						  "THEN TRUE ELSE FALSE END AS typsupporttypmod, "
+						  "0 AS typcollation "
 						  "FROM pg_catalog.pg_type "
 						  "WHERE oid = '%u'::pg_catalog.oid",
 						  tyinfo->dobj.catId.oid);
@@ -11307,6 +11313,7 @@ dumpDomain(Archive *fout, const TypeInfo *tyinfo)
 	res = ExecuteSqlQueryForSingleRow(fout, query->data);
 
 	typnotnull = PQgetvalue(res, 0, PQfnumber(res, "typnotnull"));
+	typsupporttypmod = (PQgetvalue(res, 0, PQfnumber(res, "typsupporttypmod"))[0] == 't');
 	typdefn = PQgetvalue(res, 0, PQfnumber(res, "typdefn"));
 	if (!PQgetisnull(res, 0, PQfnumber(res, "typdefaultbin")))
 		typdefault = PQgetvalue(res, 0, PQfnumber(res, "typdefaultbin"));
@@ -11324,6 +11331,10 @@ dumpDomain(Archive *fout, const TypeInfo *tyinfo)
 												 tyinfo->dobj.catId.oid,
 												 true,	/* force array type */
 												 false);	/* force multirange type */
+
+	if (typsupporttypmod)
+		appendPQExpBuffer(q,
+						"SET enable_domain_typmod = TRUE;\n");
 
 	qtypname = pg_strdup(fmtId(tyinfo->dobj.name));
 	qualtypname = pg_strdup(fmtQualifiedDumpable(tyinfo));
@@ -11370,6 +11381,10 @@ dumpDomain(Archive *fout, const TypeInfo *tyinfo)
 	}
 
 	appendPQExpBufferStr(q, ";\n");
+
+	if (typsupporttypmod)
+		appendPQExpBuffer(q,
+						"SET enable_domain_typmod = FALSE;\n");
 
 	appendPQExpBuffer(delq, "DROP DOMAIN %s;\n", qualtypname);
 

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -11384,7 +11384,7 @@ dumpDomain(Archive *fout, const TypeInfo *tyinfo)
 
 	if (typsupporttypmod)
 		appendPQExpBuffer(q,
-						"SET enable_domain_typmod = FALSE;\n");
+						"RESET enable_domain_typmod;\n");
 
 	appendPQExpBuffer(delq, "DROP DOMAIN %s;\n", qualtypname);
 


### PR DESCRIPTION
During pg_dump we loose the setting of enable_domain_typmod
GUC and hence restored domains show incorrect behaviour.

1. Fix this by dumping enable_domain_typmod guc setting
   for the domains which supports domain typmod.
2. Also, replace unnecessary sql_dialect check in function 
   `coerce_to_domain` with typname check for some predefined
    domains. T-SQL allows typmod for the following domains:
    sys.nvarchar, sys.nchar, sys.varbinary, sys.binary, sys.decimal

Task: BABEL-3107
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).