### PR TITLE
probin for pltsql func/proc is not restored properly by pg_restore

### DIFF
--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -679,7 +679,7 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 											   false);
 
 	/* perform the necessary typecasting of arguments */
-	if(sql_dialect == SQL_DIALECT_TSQL && make_fn_arguments_from_stored_proc_probin_hook != NULL)
+	if(make_fn_arguments_from_stored_proc_probin_hook != NULL)
 		(*make_fn_arguments_from_stored_proc_probin_hook)(pstate, fargs, actual_arg_types, declared_arg_types, funcid);
 	else
 		make_fn_arguments(pstate, fargs, actual_arg_types, declared_arg_types);


### PR DESCRIPTION
Since PG does not store typmod for function/procedure’s
input and output types, we store that information in probin
for T-SQL function/procedure. However, it is not properly
recovered by pg_restore.

Fixed this by making make_fn_arguments_from_stored_proc_probin_hook
dialect independent so that we always read probin if
this hook is initialised.

Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>