### PR TITLE
CREATE TABLE with column collation as latin1_general_90_bin2 fails after MVU

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -2098,9 +2098,9 @@ lookup_collation(const char *collname, Oid collnamespace, int32 encoding)
 			{
 				/* Check for encoding-specific entry (exact match) */
 				colltup = SearchSysCache3(COLLNAMEENCNSP,
-							  PointerGetDatum(xlatedCollname),
-							  Int32GetDatum(encoding),
-							  ObjectIdGetDatum(collnamespace));
+							  			  PointerGetDatum(xlatedCollname),
+							  			  Int32GetDatum(encoding),
+							  			  ObjectIdGetDatum(collnamespace));
 				if (!HeapTupleIsValid(colltup))
 					return InvalidOid;
 			}

--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -2095,7 +2095,15 @@ lookup_collation(const char *collname, Oid collnamespace, int32 encoding)
 									  ObjectIdGetDatum(collnamespace));
 			
 			if (!HeapTupleIsValid(colltup))
-				return InvalidOid;
+			{
+				/* Check for encoding-specific entry (exact match) */
+				colltup = SearchSysCache3(COLLNAMEENCNSP,
+							  PointerGetDatum(xlatedCollname),
+							  Int32GetDatum(encoding),
+							  ObjectIdGetDatum(collnamespace));
+				if (!HeapTupleIsValid(colltup))
+					return InvalidOid;
+			}
 		}
 		else
 			return InvalidOid;

--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -2098,9 +2098,9 @@ lookup_collation(const char *collname, Oid collnamespace, int32 encoding)
 			{
 				/* Check for encoding-specific entry (exact match) */
 				colltup = SearchSysCache3(COLLNAMEENCNSP,
-							  			  PointerGetDatum(xlatedCollname),
-							  			  Int32GetDatum(encoding),
-							  			  ObjectIdGetDatum(collnamespace));
+										  PointerGetDatum(xlatedCollname),
+										  Int32GetDatum(encoding),
+										  ObjectIdGetDatum(collnamespace));
 				if (!HeapTupleIsValid(colltup))
 					return InvalidOid;
 			}


### PR DESCRIPTION
Collation latin1_general_90_bin2, translated to bbf_unicode_bin2,
has collencoding = -1 on a freshly installed server but it gets
changed to databaseCollation (collencoding = PG_UTF8) after MVU.
While in lookup_collation function, we search collation tuple
only with encoding = -1 and fail to find the tuple. That's why
CREATE TABLE with this collation fails with the error that
"collation %s for encoding UTF8 does not exists".

Fixed this by adding a second search with given encoding if
we fail to find the collation with encoding = -1.

Task: BABEL-3182
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>