### PR TITLE
MVU fails while restoring MS-TVF and procedure with T-SQL table-type

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -53,7 +53,7 @@ is_babelfish_database(Archive *fout)
 
 		tsql_extension_installed = (bool *) palloc(sizeof(bool));
 
-		res = ExecuteSqlQueryForSingleRow(fout, "SELECT extname FROM pg_extension WHERE extname = 'babelfishpg_tsql';");
+		res = ExecuteSqlQuery(fout, "SELECT extname FROM pg_extension WHERE extname = 'babelfishpg_tsql';", PGRES_TUPLES_OK);
 		*tsql_extension_installed = PQntuples(res) != 0;
 		PQclear(res);
 	}

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -15,8 +15,8 @@
 #include "pg_dump.h"
 
 extern void bbf_selectDumpableCast(CastInfo *cast);
-extern void bbf_fixTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype);
-extern bool bbf_is_tsqltabletype(Archive *fout, const TableInfo *tbinfo);
-extern bool bbf_is_tsql_mstvf(Archive *fout, FuncInfo *finfo, char prokind, bool proretset);
+extern void bbf_fixTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
+extern bool bbf_isTsqlTableType(Archive *fout, const TableInfo *tbinfo);
+extern bool bbf_isTsqlMstvf(Archive *fout, FuncInfo *finfo, char prokind, bool proretset);
 
 #endif

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -15,5 +15,8 @@
 #include "pg_dump.h"
 
 extern void bbf_selectDumpableCast(CastInfo *cast);
+extern void bbf_fixTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype);
+extern bool bbf_is_tsqltabletype(Archive *fout, const TableInfo *tbinfo);
+extern bool bbf_is_tsql_mstvf(Archive *fout, FuncInfo *finfo, char prokind, bool proretset);
 
 #endif

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -15,8 +15,8 @@
 #include "pg_dump.h"
 
 extern void bbf_selectDumpableCast(CastInfo *cast);
-extern void bbf_fixTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
-extern bool bbf_isTsqlTableType(Archive *fout, const TableInfo *tbinfo);
-extern bool bbf_isTsqlMstvf(Archive *fout, FuncInfo *finfo, char prokind, bool proretset);
+extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
+extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);
+extern bool isTsqlMstvf(Archive *fout, const FuncInfo *finfo, char prokind, bool proretset);
 
 #endif

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -12388,7 +12388,7 @@ dumpFunc(Archive *fout, const FuncInfo *finfo)
 	else
 		keyword = "FUNCTION";	/* works for window functions too */
 	
-	is_tsql_mstvf = bbf_is_tsql_mstvf(fout, finfo, prokind[0], proretset[0] == 't');
+	is_tsql_mstvf = bbf_isTsqlMstvf(fout, finfo, prokind[0], proretset[0] == 't');
 
 	if (is_tsql_mstvf)
 		appendPQExpBufferStr(q,
@@ -15905,7 +15905,7 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 		char	   *ftoptions = NULL;
 		char	   *srvname = NULL;
 		char	   *foreign = "";
-		bool	   tsql_tabletype = bbf_is_tsqltabletype(fout, tbinfo);
+		bool	   tsql_tabletype = bbf_isTsqlTableType(fout, tbinfo);
 
 		switch (tbinfo->relkind)
 		{
@@ -18583,10 +18583,12 @@ getDependencies(Archive *fout)
 			addObjectDependency(dobj, refdobj->dumpId);
 
 		/* Standalone T-SQL table-type as a function's argument or multi-statement TVF */
-		if (deptype == 'n' &&
-			dobj->objType == DO_FUNC &&
+		if (dobj->objType == DO_FUNC &&
 			refdobj->objType == DO_DUMMY_TYPE)
-			bbf_fixTableTypeDependency(fout, dobj, refdobj);
+			bbf_fixTableTypeDependency(fout, dobj, refdobj, deptype);
+		else if (dobj->objType == DO_DUMMY_TYPE &&
+				refdobj->objType == DO_FUNC)
+			bbf_fixTableTypeDependency(fout, refdobj, dobj, deptype);
 	}
 
 	PQclear(res);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -18567,17 +18567,6 @@ getDependencies(Archive *fout)
 			dobj->objType == DO_TABLE &&
 			refdobj->objType == DO_TYPE)
 			addObjectDependency(refdobj, dobj->dumpId);
-		/*
-		 * T-SQL table-type's template table has implicit dependency upon
-		 * it; which is also right thing for DROP but it doesn't produce
-		 * the dependency ordering we need. So in this case also, we reverse
-		 * the direction of the dependency.
-		 */
-		else if (deptype == 'i' &&
-				 dobj->objType == DO_TABLE &&
-				 refdobj->objType == DO_DUMMY_TYPE &&
-				 !((TypeInfo *) refdobj)->isArray)
-			addObjectDependency(refdobj, dobj->dumpId);
 		else
 			/* normal case */
 			addObjectDependency(dobj, refdobj->dumpId);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -12388,7 +12388,7 @@ dumpFunc(Archive *fout, const FuncInfo *finfo)
 	else
 		keyword = "FUNCTION";	/* works for window functions too */
 	
-	is_tsql_mstvf = bbf_isTsqlMstvf(fout, finfo, prokind[0], proretset[0] == 't');
+	is_tsql_mstvf = isTsqlMstvf(fout, finfo, prokind[0], proretset[0] == 't');
 
 	if (is_tsql_mstvf)
 		appendPQExpBufferStr(q,
@@ -15905,7 +15905,7 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 		char	   *ftoptions = NULL;
 		char	   *srvname = NULL;
 		char	   *foreign = "";
-		bool	   tsql_tabletype = bbf_isTsqlTableType(fout, tbinfo);
+		bool	   tsql_tabletype = isTsqlTableType(fout, tbinfo);
 
 		switch (tbinfo->relkind)
 		{
@@ -18583,12 +18583,7 @@ getDependencies(Archive *fout)
 			addObjectDependency(dobj, refdobj->dumpId);
 
 		/* Standalone T-SQL table-type as a function's argument or multi-statement TVF */
-		if (dobj->objType == DO_FUNC &&
-			refdobj->objType == DO_DUMMY_TYPE)
-			bbf_fixTableTypeDependency(fout, dobj, refdobj, deptype);
-		else if (dobj->objType == DO_DUMMY_TYPE &&
-				refdobj->objType == DO_FUNC)
-			bbf_fixTableTypeDependency(fout, refdobj, dobj, deptype);
+		fixTsqlTableTypeDependency(fout, dobj, refdobj, deptype);
 	}
 
 	PQclear(res);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -12392,7 +12392,7 @@ dumpFunc(Archive *fout, const FuncInfo *finfo)
 
 	if (is_tsql_mstvf)
 		appendPQExpBufferStr(q,
-							 "SET babelfishpg_tsql.tsql_tabletype = TRUE;\n");
+							 "SET babelfishpg_tsql.restore_tsql_tabletype = TRUE;\n");
 
 	appendPQExpBuffer(delqry, "DROP %s %s.%s;\n",
 					  keyword,
@@ -12550,7 +12550,7 @@ dumpFunc(Archive *fout, const FuncInfo *finfo)
 
 	if (is_tsql_mstvf)
 		appendPQExpBufferStr(q,
-							 "RESET babelfishpg_tsql.tsql_tabletype;\n");
+							 "RESET babelfishpg_tsql.restore_tsql_tabletype;\n");
 
 	append_depends_on_extension(fout, q, &finfo->dobj,
 								"pg_catalog.pg_proc", keyword,
@@ -15961,7 +15961,7 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 
 		if (tsql_tabletype)
 			appendPQExpBufferStr(q,
-								 "SET babelfishpg_tsql.tsql_tabletype = TRUE;\n");
+								 "SET babelfishpg_tsql.restore_tsql_tabletype = TRUE;\n");
 
 		appendPQExpBuffer(q, "CREATE %s%s %s",
 						  tbinfo->relpersistence == RELPERSISTENCE_UNLOGGED ?
@@ -16186,7 +16186,7 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 
 		if (tsql_tabletype)
 			appendPQExpBufferStr(q,
-								 "RESET babelfishpg_tsql.tsql_tabletype;\n");
+								 "RESET babelfishpg_tsql.restore_tsql_tabletype;\n");
 
 		/* Materialized views can depend on extensions */
 		if (tbinfo->relkind == RELKIND_MATVIEW)

--- a/src/bin/pg_dump/pg_dump_sort.c
+++ b/src/bin/pg_dump/pg_dump_sort.c
@@ -988,6 +988,28 @@ repairDependencyLoop(DumpableObject **loop,
 		return;
 	}
 
+	/*
+	 * A multi-statement TVF will have dependency loop with it's
+	 * underlying table-type, which is right thing for DROP but
+	 * it doesn't produce the dependency ordering we need.
+	 * Break the loop by removing table-type's dependency on
+	 * TVF.
+	 */
+	if (nLoop == 2 &&
+		loop[0]->objType == DO_DUMMY_TYPE &&
+		loop[1]->objType == DO_FUNC)
+	{
+		removeObjectDependency(loop[0], loop[1]->dumpId);
+		return;
+	}
+	if (nLoop == 2 &&
+		loop[1]->objType == DO_DUMMY_TYPE &&
+		loop[0]->objType == DO_FUNC)
+	{
+		removeObjectDependency(loop[1], loop[0]->dumpId);
+		return;
+	}
+
 	/* View (including matview) and its ON SELECT rule */
 	if (nLoop == 2 &&
 		loop[0]->objType == DO_TABLE &&

--- a/src/bin/pg_dump/pg_dump_sort.c
+++ b/src/bin/pg_dump/pg_dump_sort.c
@@ -988,28 +988,6 @@ repairDependencyLoop(DumpableObject **loop,
 		return;
 	}
 
-	/*
-	 * A multi-statement TVF will have dependency loop with it's
-	 * underlying table-type, which is right thing for DROP but
-	 * it doesn't produce the dependency ordering we need.
-	 * Break the loop by removing table-type's dependency on
-	 * TVF.
-	 */
-	if (nLoop == 2 &&
-		loop[0]->objType == DO_DUMMY_TYPE &&
-		loop[1]->objType == DO_FUNC)
-	{
-		removeObjectDependency(loop[0], loop[1]->dumpId);
-		return;
-	}
-	if (nLoop == 2 &&
-		loop[1]->objType == DO_DUMMY_TYPE &&
-		loop[0]->objType == DO_FUNC)
-	{
-		removeObjectDependency(loop[1], loop[0]->dumpId);
-		return;
-	}
-
 	/* View (including matview) and its ON SELECT rule */
 	if (nLoop == 2 &&
 		loop[0]->objType == DO_TABLE &&


### PR DESCRIPTION
This commit fixes following three issues with T-SQL table-type:

1. While restoring MS-TVF, PG throws error that underlying
   "table-type does not exists", which is due to dependencies
   between function, table-type and underlying template table
   are not getting handled properly by pg_dump.
2. While restoring procedure with one of it's argument as T-SQL
   table-type, PG's throws the same error that "table-type
   does not exists". This is again a dependency issue.
3. We have added a new field "tsql_tabletype" to CreateStmt
   structure but and it is not getting captured by pg_dump.

Fixes:

1. Resolve dependency loop between MS-TVF and it's return
   type (T-SQL table-type).
2. Add function's dependency upon template table instead of
   underlying table-type (dummy type), since template table
   should be restored first so that it's row type (table-type)
   gets created automatically and becomes available to be used
   by other functions/procedures.
3. Set babelfishpg_tsql.restore_tsql_tabletype guc before restoring
   table-type's underlying template table in order to let backend
   recreate the correct dependencies between MS-TVF, table-type
   and underlying template table.

Task: BABEL-3192
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>