### PR TITLE
Set babelfishpg_tsql.dump_restore GUC to TRUE for all PL/tsql ITVF

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -225,7 +225,39 @@ isTsqlMstvf(Archive *fout, const FuncInfo *finfo, char prokind, bool proretset)
 	rettype = findTypeByOid(finfo->prorettype);
 	lanname = getLanguageName(fout, finfo->lang);
 
-	if (rettype->typtype == TYPTYPE_COMPOSITE &&
+	if (rettype && lanname &&
+		rettype->typtype == TYPTYPE_COMPOSITE &&
+		strcmp(lanname, "pltsql") == 0)
+	{
+		free(lanname);
+		return true;
+	}
+
+	free(lanname);
+	return false;
+}
+
+/*
+ * isTsqlItvf:
+ * Returns true if given function is T-SQL inline table
+ * valued function (ITVF), false otherwise.
+ * A function is ITVF if it returns set (TABLE) but
+ * it's return type is not composite type.
+ */
+bool
+isTsqlItvf(Archive *fout, const FuncInfo *finfo, char prokind, bool proretset)
+{
+	TypeInfo *rettype;
+	char	 *lanname;
+
+	if (!isBabelfishDatabase(fout) || prokind == PROKIND_PROCEDURE || !proretset)
+		return false;
+
+	rettype = findTypeByOid(finfo->prorettype);
+	lanname = getLanguageName(fout, finfo->lang);
+
+	if (rettype && lanname &&
+		rettype->typtype != TYPTYPE_COMPOSITE &&
 		strcmp(lanname, "pltsql") == 0)
 	{
 		free(lanname);

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -13,6 +13,7 @@
 #define DUMP_BABEL_UTILS_H
 
 #include "pg_dump.h"
+#include "pqexpbuffer.h"
 
 /* PL/tsql table valued function types */
 #define PLTSQL_TVFTYPE_NONE  0
@@ -24,5 +25,6 @@ extern void bbf_selectDumpableCast(CastInfo *cast);
 extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
 extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);
 extern int getTsqlTvfType(Archive *fout, const FuncInfo *finfo, char prokind, bool proretset);
+extern void setOrResetPltsqlFuncRestoreGUCs(Archive *fout, PQExpBuffer q, const FuncInfo *finfo, char prokind, bool proretset, bool is_set);
 
 #endif

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -18,5 +18,6 @@ extern void bbf_selectDumpableCast(CastInfo *cast);
 extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
 extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);
 extern bool isTsqlMstvf(Archive *fout, const FuncInfo *finfo, char prokind, bool proretset);
+extern bool isTsqlItvf(Archive *fout, const FuncInfo *finfo, char prokind, bool proretset);
 
 #endif

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -14,10 +14,15 @@
 
 #include "pg_dump.h"
 
+/* PL/tsql table valued function types */
+#define PLTSQL_TVFTYPE_NONE  0
+#define PLTSQL_TVFTYPE_MSTVF 1
+#define PLTSQL_TVFTYPE_ITVF  2
+
+
 extern void bbf_selectDumpableCast(CastInfo *cast);
 extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
 extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);
-extern bool isTsqlMstvf(Archive *fout, const FuncInfo *finfo, char prokind, bool proretset);
-extern bool isTsqlItvf(Archive *fout, const FuncInfo *finfo, char prokind, bool proretset);
+extern int getTsqlTvfType(Archive *fout, const FuncInfo *finfo, char prokind, bool proretset);
 
 #endif

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -12123,6 +12123,7 @@ dumpFunc(Archive *fout, const FuncInfo *finfo)
 	const char *keyword;
 	int			i;
 	bool		is_tsql_mstvf = false;
+	bool		is_tsql_itvf = false;
 
 	/* Skip if not to be dumped */
 	if (!finfo->dobj.dump || dopt->dataOnly)
@@ -12389,12 +12390,13 @@ dumpFunc(Archive *fout, const FuncInfo *finfo)
 		keyword = "FUNCTION";	/* works for window functions too */
 	
 	is_tsql_mstvf = isTsqlMstvf(fout, finfo, prokind[0], proretset[0] == 't');
+	is_tsql_itvf = isTsqlItvf(fout, finfo, prokind[0], proretset[0] == 't');
 
 	if (is_tsql_mstvf)
 		appendPQExpBufferStr(q,
 							 "SET babelfishpg_tsql.restore_tsql_tabletype = TRUE;\n");
 
-	if (strcmp(lanname, "pltsql") == 0)
+	if (is_tsql_itvf)
 		appendPQExpBufferStr(q,
 							 "SET babelfishpg_tsql.dump_restore = TRUE;\n");
 
@@ -12552,7 +12554,7 @@ dumpFunc(Archive *fout, const FuncInfo *finfo)
 
 	appendPQExpBuffer(q, "\n    %s;\n", asPart->data);
 
-	if (strcmp(lanname, "pltsql") == 0)
+	if (is_tsql_itvf)
 		appendPQExpBufferStr(q,
 							 "RESET babelfishpg_tsql.dump_restore;\n");
 

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -12394,6 +12394,10 @@ dumpFunc(Archive *fout, const FuncInfo *finfo)
 		appendPQExpBufferStr(q,
 							 "SET babelfishpg_tsql.restore_tsql_tabletype = TRUE;\n");
 
+	if (strcmp(lanname, "pltsql") == 0)
+		appendPQExpBufferStr(q,
+							 "SET babelfishpg_tsql.dump_restore = TRUE;\n");
+
 	appendPQExpBuffer(delqry, "DROP %s %s.%s;\n",
 					  keyword,
 					  fmtId(finfo->dobj.namespace->dobj.name),
@@ -12547,6 +12551,10 @@ dumpFunc(Archive *fout, const FuncInfo *finfo)
 	}
 
 	appendPQExpBuffer(q, "\n    %s;\n", asPart->data);
+
+	if (strcmp(lanname, "pltsql") == 0)
+		appendPQExpBufferStr(q,
+							 "RESET babelfishpg_tsql.dump_restore;\n");
 
 	if (is_tsql_mstvf)
 		appendPQExpBufferStr(q,


### PR DESCRIPTION
MVU fails while restoring inline table valued functions (ITVF) due to
following two reasons:
1. Function's body compilation fails in the validator function.
2. Validator complains that PL/tsql function can't return type
     text/ntext/image.

Fix for these two issues will be in PL/tsql validator function, but
we will set babelfishpg_tsql.dump_restore GUC to TRUE for
all ITVF functions during dump and use this GUC to take
certain decisions during restore.
Additionally, refractored code to use function `getTsqlTvfType(...)`
to get the type of PL/tsql table valued function (MS-TVF, ITVF
or NONE).

Task: BABEL-3204
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>