### PR TITLE
Fix a syntax error in datetime2/smalldatetime/datetimeoffset columns while MVU

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -174,6 +174,8 @@ static RoleSpec *makeRoleSpec(RoleSpecType type, int location);
 static void check_qualified_name(List *names, core_yyscan_t yyscanner);
 static List *check_func_name(List *names, core_yyscan_t yyscanner);
 static List *check_indirection(List *indirection, core_yyscan_t yyscanner);
+static bool check_generic_type_with_or_without_time_zone(const TypeName *typname,
+														 bool with_time_zone);
 static List *extractArgTypes(List *parameters);
 static List *extractAggrArgTypes(List *aggrargs);
 static List *makeOrderedSetArgs(List *directargs, List *orderedargs,
@@ -12948,29 +12950,17 @@ GenericType:
 					 * Because we have another special handling in printTypmod(),
 					 * this rule can be removed in PG15.
 					 */
-					const char *dump_restore = GetConfigOption("babelfishpg_tsql.dump_restore", true, false);
-					if (!dump_restore || strcmp(dump_restore, "on") != 0)
-					{
+					TypeName *typname = makeTypeNameFromNameList(lcons(makeString($1), $2));
+
+					if (!check_generic_type_with_or_without_time_zone(typname, false /* without time zone */))
 						ereport(ERROR,
 								(errcode(ERRCODE_SYNTAX_ERROR),
 									errmsg("syntax error at or near \"without\""),
 									parser_errposition(@4)));
-					}
-					$$ = makeTypeNameFromNameList(lcons(makeString($1), $2));
-					if (strcmp(strVal(linitial($$->names)), "sys") == 0 &&
-						(strcmp(strVal(lsecond($$->names)), "datetime2") == 0 ||
-							strcmp(strVal(lsecond($$->names)), "smalldatetime") == 0))
-					{
-						$$->typmods = $3;
-						$$->location = @1;
-					}
-					else
-					{
-						ereport(ERROR,
-								(errcode(ERRCODE_SYNTAX_ERROR),
-									errmsg("syntax error at or near \"without\""),
-									parser_errposition(@4)));
-					}
+
+					$$ = typname;
+					$$->typmods = $3;
+					$$->location = @1;
 				}
 			| type_function_name attrs opt_type_modifiers WITH_LA TIME ZONE
 				{
@@ -12981,28 +12971,17 @@ GenericType:
 					 * Because we have another special handling in printTypmod(),
 					 * this rule can be removed in PG15.
 					 */
-					const char *dump_restore = GetConfigOption("babelfishpg_tsql.dump_restore", true, false);
-					if (!dump_restore || strcmp(dump_restore, "on") != 0)
-					{
+					TypeName *typname = makeTypeNameFromNameList(lcons(makeString($1), $2));
+
+					if (!check_generic_type_with_or_without_time_zone(typname, true /* with time zone */))
 						ereport(ERROR,
 								(errcode(ERRCODE_SYNTAX_ERROR),
 									errmsg("syntax error at or near \"with\""),
 									parser_errposition(@4)));
-					}
-					$$ = makeTypeNameFromNameList(lcons(makeString($1), $2));
-					if (strcmp(strVal(linitial($$->names)), "sys") == 0 &&
-						strcmp(strVal(lsecond($$->names)), "datetimeoffset") == 0)
-					{
-						$$->typmods = $3;
-						$$->location = @1;
-					}
-					else
-					{
-						ereport(ERROR,
-								(errcode(ERRCODE_SYNTAX_ERROR),
-									errmsg("syntax error at or near \"with\""),
-									parser_errposition(@4)));
-					}
+
+					$$ = typname;
+					$$->typmods = $3;
+					$$->location = @1;
 				}
 		;
 
@@ -16948,6 +16927,36 @@ check_indirection(List *indirection, core_yyscan_t yyscanner)
 		}
 	}
 	return indirection;
+}
+
+/*
+ * Generic Type with/without time zone syntax should be allowed
+ * only for certain T-SQL datatypes during dump and restore.
+ */
+static bool
+check_generic_type_with_or_without_time_zone(const TypeName *typname, bool with_time_zone)
+{
+	const char *dump_restore = GetConfigOption("babelfishpg_tsql.dump_restore", true, false);
+
+	if (!dump_restore || strcmp(dump_restore, "on") != 0)
+		return false; /* not allowed */
+
+	if (strcmp(strVal(linitial(typname->names)), "sys") != 0)
+		return false; /* not allowed */
+
+	if (with_time_zone)
+	{
+		if (strcmp(strVal(lsecond(typname->names)), "datetimeoffset") == 0)
+			return true; /* allowed */
+	}
+	else
+	{
+		if (strcmp(strVal(lsecond(typname->names)), "datetime2") == 0 ||
+			strcmp(strVal(lsecond(typname->names)), "smalldatetime") == 0)
+			return true; /* allowed */
+	}
+
+	return false; /* not allowed */
 }
 
 /* extractArgTypes()

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -214,9 +214,6 @@ static Node *makeRecursiveViewSelect(char *relname, List *aliases, Node *query);
 rewrite_typmod_expr_hook_type rewrite_typmod_expr_hook = NULL;
 validate_numeric_typmods_hook_type validate_numeric_typmods_hook = NULL;
 check_recursive_cte_hook_type check_recursive_cte_hook = NULL;
-
-/* Dump and Restore */
-bool restore_tsql_datetime2 = false;
 %}
 
 %pure-parser
@@ -12951,7 +12948,8 @@ GenericType:
 					 * Because we have another special handling in printTypmod(),
 					 * this rule can be removed in PG15.
 					 */
-					if (!restore_tsql_datetime2)
+					const char *dump_restore = GetConfigOption("babelfishpg_tsql.dump_restore", true, false);
+					if (!dump_restore || strcmp(dump_restore, "on") != 0)
 					{
 						ereport(ERROR,
 								(errcode(ERRCODE_SYNTAX_ERROR),
@@ -12983,7 +12981,8 @@ GenericType:
 					 * Because we have another special handling in printTypmod(),
 					 * this rule can be removed in PG15.
 					 */
-					if (!restore_tsql_datetime2)
+					const char *dump_restore = GetConfigOption("babelfishpg_tsql.dump_restore", true, false);
+					if (!dump_restore || strcmp(dump_restore, "on") != 0)
 					{
 						ereport(ERROR,
 								(errcode(ERRCODE_SYNTAX_ERROR),

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -12955,7 +12955,7 @@ GenericType:
 					{
 						ereport(ERROR,
 								(errcode(ERRCODE_SYNTAX_ERROR),
-									errmsg("\"without time zone\" is only valid during restore"),
+									errmsg("syntax error at or near \"without\""),
 									parser_errposition(@4)));
 					}
 					$$ = makeTypeNameFromNameList(lcons(makeString($1), $2));
@@ -12970,7 +12970,7 @@ GenericType:
 					{
 						ereport(ERROR,
 								(errcode(ERRCODE_SYNTAX_ERROR),
-									errmsg("\"without time zone\" is only valid for sys.datetime2 and sys.smalldatetime"),
+									errmsg("syntax error at or near \"without\""),
 									parser_errposition(@4)));
 					}
 				}

--- a/src/backend/utils/adt/format_type.c
+++ b/src/backend/utils/adt/format_type.c
@@ -380,6 +380,7 @@ printTypmod(const char *typname, int32 typmod, Oid typmodout)
 	{
 		/* Use the type-specific typmodout procedure */
 		char	   *tmstr;
+		char	   *tzstr = " without time zone";
 
 		tmstr = DatumGetCString(OidFunctionCall1(typmodout,
 												 Int32GetDatum(typmod)));
@@ -395,9 +396,9 @@ printTypmod(const char *typname, int32 typmod, Oid typmodout)
 		if (strcmp("sys.datetime2", typname) == 0 ||
 			strcmp("sys.smalldatetime", typname) == 0)
 		{
-			char *substr = strstr(tmstr, " without time zone");
+			char *substr = strstr(tmstr, tzstr);
 			if (substr)
-				*substr = '\0';
+				memmove(substr, substr + strlen(tzstr), strlen(substr + strlen(tzstr)) + 1);
 		}
 		res = psprintf("%s%s", typname, tmstr);
 	}

--- a/src/backend/utils/adt/format_type.c
+++ b/src/backend/utils/adt/format_type.c
@@ -380,8 +380,6 @@ printTypmod(const char *typname, int32 typmod, Oid typmodout)
 	{
 		/* Use the type-specific typmodout procedure */
 		char	   *tmstr;
-		char	   *datetime2 = "sys.datetime2";
-		char	   *smalldatetime = "sys.smalldatetime";
 
 		tmstr = DatumGetCString(OidFunctionCall1(typmodout,
 												 Int32GetDatum(typmod)));
@@ -394,8 +392,8 @@ printTypmod(const char *typname, int32 typmod, Oid typmodout)
 		 * 2. there are no user objects using the old
 		 *    typmod in/out functions, i.e., in PG15.
 		 */
-		if (strncmp(datetime2, typname, strlen(datetime2)) == 0 ||
-			strncmp(smalldatetime, typname, strlen(smalldatetime)) == 0)
+		if (strcmp("sys.datetime2", typname) == 0 ||
+			strcmp("sys.smalldatetime", typname) == 0)
 		{
 			char *substr = strstr(tmstr, " without time zone");
 			if (substr)

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -270,16 +270,6 @@ setOrResetPltsqlFuncRestoreGUCs(Archive *fout, PQExpBuffer q, const FuncInfo *fi
 								 "RESET babelfishpg_tsql.restore_tsql_tabletype;\n");
 			break;
 		}
-		case PLTSQL_TVFTYPE_ITVF:
-		{
-			if (is_set)
-				appendPQExpBufferStr(q,
-								 "SET babelfishpg_tsql.dump_restore = TRUE;\n");
-			else
-				appendPQExpBufferStr(q,
-								 "RESET babelfishpg_tsql.dump_restore;\n");
-			break;
-		}
 		default:
 			break;
 	}

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -41,7 +41,7 @@ getLanguageName(Archive *fout, Oid langid)
  * returns true if current database has "babelfishpg_tsql"
  * extension installed, false otherwise.
  */
-static bool
+bool
 isBabelfishDatabase(Archive *fout)
 {
 	PGresult *res;

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -15,6 +15,7 @@
 #include "pg_dump.h"
 
 extern void bbf_selectDumpableCast(CastInfo *cast);
+extern bool isBabelfishDatabase(Archive *fout);
 extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
 extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);
 extern bool isTsqlMstvf(Archive *fout, const FuncInfo *finfo, char prokind, bool proretset);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -10521,6 +10521,9 @@ dumpExtension(Archive *fout, const ExtensionInfo *extinfo)
 
 	qextname = pg_strdup(fmtId(extinfo->dobj.name));
 
+	if (strcmp(qextname, "babelfishpg_common") == 0 && isBabelfishDatabase(fout))
+		appendPQExpBuffer(q, "SET babelfishpg_tsql.restore_tsql_datetime2 = TRUE;\n");
+
 	appendPQExpBuffer(delq, "DROP EXTENSION %s;\n", qextname);
 
 	if (!dopt->binary_upgrade)

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -10522,7 +10522,7 @@ dumpExtension(Archive *fout, const ExtensionInfo *extinfo)
 	qextname = pg_strdup(fmtId(extinfo->dobj.name));
 
 	if (strstr(qextname, "babelfishpg_common") && isBabelfishDatabase(fout))
-		appendPQExpBuffer(q, "SET babelfishpg_tsql.restore_tsql_datetime2 = TRUE;\n");
+		appendPQExpBuffer(q, "SET babelfishpg_tsql.dump_restore = TRUE;\n");
 
 	appendPQExpBuffer(delq, "DROP EXTENSION %s;\n", qextname);
 

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -10521,7 +10521,7 @@ dumpExtension(Archive *fout, const ExtensionInfo *extinfo)
 
 	qextname = pg_strdup(fmtId(extinfo->dobj.name));
 
-	if (strcmp(qextname, "babelfishpg_common") == 0 && isBabelfishDatabase(fout))
+	if (strstr(qextname, "babelfishpg_common") && isBabelfishDatabase(fout))
 		appendPQExpBuffer(q, "SET babelfishpg_tsql.restore_tsql_datetime2 = TRUE;\n");
 
 	appendPQExpBuffer(delq, "DROP EXTENSION %s;\n", qextname);

--- a/src/include/parser/parser.h
+++ b/src/include/parser/parser.h
@@ -92,6 +92,9 @@ extern bool pltsql_case_insensitive_identifiers;
 
 extern char* pltsql_server_collation_name;
 
+/* Dump and Restore */
+extern bool restore_tsql_datetime2;
+
 /* Primary entry point for the raw parsing functions */
 extern List *raw_parser(const char *str, RawParseMode mode);
 

--- a/src/include/parser/parser.h
+++ b/src/include/parser/parser.h
@@ -92,9 +92,6 @@ extern bool pltsql_case_insensitive_identifiers;
 
 extern char* pltsql_server_collation_name;
 
-/* Dump and Restore */
-extern bool restore_tsql_datetime2;
-
 /* Primary entry point for the raw parsing functions */
 extern List *raw_parser(const char *str, RawParseMode mode);
 


### PR DESCRIPTION
Since sys.datetime2, sys.smalldatetime, and sys.datetimeoffset use PG's timestamp typmod
in/out functions, pg_dump adds "with/without time zone" clause and it causes
a syntax error when restoring objects using those columns.

To allow MVU (Major Version Upgrade) from PG13 to PG14 for objects using
those types, this commit adds a special gram rule that can parse
datetime2/smalldatetime/datetimeoffset columns even with "with/without time zone" clause.

Also, it adds another special handling in printTypmod() removing the
problematic clause when we call pg_catalog.format_type() function.
As a result, we will be able to remove the special gram rule in PG15.

Task: BABEL-3190
Signed-off-by: Jungkook Lee <jungkook@amazon.com>