### PR TITLE
Load Babelfish extensions right after sys schema is created

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -88,6 +88,25 @@ bbf_selectDumpableCast(CastInfo *cast)
 }
 
 /*
+ * At MVU startup, some initialization steps are skipped
+ * because the sys schema does not exist.
+ * This function fills these gaps, such as creating some in-memory hash tables
+ * by explicitly loading extensions.
+ */
+void
+loadBabelfishExtensions(Archive *fout, const char *qnspname, PQExpBuffer buf)
+{
+	if (!isBabelfishDatabase(fout))
+		return;
+
+	if (strcmp(qnspname, "\"sys\"") != 0 && strcmp(qnspname, "sys") != 0)
+		return;
+
+	appendPQExpBuffer(buf, "LOAD 'babelfishpg_common';\n");
+	appendPQExpBuffer(buf, "LOAD 'babelfishpg_tsql';\n");
+}
+
+/*
  * fixTsqlTableTypeDependency:
  * Fixes following two types of dependency issues between T-SQL
  * table-type and T-SQL MS-TVF/procedure:

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -23,6 +23,7 @@
 
 extern void bbf_selectDumpableCast(CastInfo *cast);
 extern bool isBabelfishDatabase(Archive *fout);
+extern void loadBabelfishExtensions(Archive *fout, const char *qnspname, PQExpBuffer buf);
 extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
 extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);
 extern int getTsqlTvfType(Archive *fout, const FuncInfo *finfo, char prokind, bool proretset);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -10464,6 +10464,8 @@ dumpNamespace(Archive *fout, const NamespaceInfo *nspinfo)
 
 	appendPQExpBuffer(q, "CREATE SCHEMA %s;\n", qnspname);
 
+	loadBabelfishExtensions(fout, qnspname, q);
+
 	if (dopt->binary_upgrade)
 		binary_upgrade_extension_member(q, &nspinfo->dobj,
 										"SCHEMA", qnspname, NULL);


### PR DESCRIPTION
At MVU startup, some initialization steps are skipped because "sys"
schema does not exist. This commit fills those gaps, such as creating
some in-memory hash tables, by explicitly loading extensions.

However, we don't have a concrete test case affected by this change so
we regard this as a preventive measure.

Task: BABEL-3189
Signed-off-by: Jungkook Lee <jungkook@amazon.com>