### PR TITLE
CREATE VIEW fails in UNION if column datatypes are from different categories during MVU

### DIFF
--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -27,6 +27,7 @@
 #include "parser/parse_type.h"
 #include "utils/builtins.h"
 #include "utils/datum.h"		/* needed for datumIsEqual() */
+#include "utils/guc.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
@@ -1380,6 +1381,7 @@ select_common_type(ParseState *pstate, List *exprs, const char *context,
 	TYPCATEGORY pcategory;
 	bool		pispreferred;
 	ListCell   *lc;
+	const char *dump_restore = GetConfigOption("babelfishpg_tsql.dump_restore", true, false);
 
 	Assert(exprs != NIL);
 	pexpr = (Node *) linitial(exprs);
@@ -1437,8 +1439,9 @@ select_common_type(ParseState *pstate, List *exprs, const char *context,
 				pcategory = ncategory;
 				pispreferred = nispreferred;
 			}
-			else if (ncategory != pcategory
-				&& sql_dialect != SQL_DIALECT_TSQL) /* T-SQL allows to select common datatype between different categories */
+			else if (ncategory != pcategory &&
+				sql_dialect != SQL_DIALECT_TSQL && /* T-SQL allows to select common datatype between different categories */
+				(!dump_restore || (dump_restore && strcmp(dump_restore, "on") != 0))) /* allow common datatype between different categories if dump_restore GUC is set */
 			{
 				/*
 				 * both types in different categories? then not much hope...
@@ -1468,7 +1471,8 @@ select_common_type(ParseState *pstate, List *exprs, const char *context,
 				pcategory = ncategory;
 				pispreferred = nispreferred;
 			}
-			else if (sql_dialect == SQL_DIALECT_TSQL &&
+			else if ((sql_dialect == SQL_DIALECT_TSQL ||
+					 (dump_restore && strcmp(dump_restore, "on") == 0)) &&
 					 determine_datatype_precedence_hook != NULL &&
 					 !pispreferred &&
 					 can_coerce_type(1, &ptype, &ntype, COERCION_IMPLICIT) &&
@@ -3202,6 +3206,7 @@ find_coercion_pathway(Oid targetTypeId, Oid sourceTypeId,
 {
 	CoercionPathType result = COERCION_PATH_NONE;
 	HeapTuple	tuple;
+	const char *dump_restore = GetConfigOption("babelfishpg_tsql.dump_restore", true, false);
 
 	*funcid = InvalidOid;
 
@@ -3209,7 +3214,8 @@ find_coercion_pathway(Oid targetTypeId, Oid sourceTypeId,
 	 * T-SQL allows more implicit casting in general.
 	 * check if rules (defiend with "assignment" property) is supported in T-SQL
 	 */
-	if (sql_dialect == SQL_DIALECT_TSQL &&
+	if ((sql_dialect == SQL_DIALECT_TSQL ||
+	    (dump_restore && strcmp(dump_restore, "on") == 0)) && /* execute hook if dialect is T-SQL or T-SQL's dump_restore GUC is set */
 	    find_coercion_pathway_hook != NULL)
 	{
 		result = find_coercion_pathway_hook(sourceTypeId, targetTypeId, ccontext, funcid);

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -1441,7 +1441,7 @@ select_common_type(ParseState *pstate, List *exprs, const char *context,
 			}
 			else if (ncategory != pcategory &&
 				sql_dialect != SQL_DIALECT_TSQL && /* T-SQL allows to select common datatype between different categories */
-				(!dump_restore || (dump_restore && strcmp(dump_restore, "on") != 0))) /* allow common datatype between different categories if dump_restore GUC is set */
+				(!dump_restore || (dump_restore && strcmp(dump_restore, "on") != 0))) /* allow common datatype between different categories while restoring babelfish database */
 			{
 				/*
 				 * both types in different categories? then not much hope...
@@ -3215,7 +3215,7 @@ find_coercion_pathway(Oid targetTypeId, Oid sourceTypeId,
 	 * check if rules (defiend with "assignment" property) is supported in T-SQL
 	 */
 	if ((sql_dialect == SQL_DIALECT_TSQL ||
-	    (dump_restore && strcmp(dump_restore, "on") == 0)) && /* execute hook if dialect is T-SQL or T-SQL's dump_restore GUC is set */
+	    (dump_restore && strcmp(dump_restore, "on") == 0)) && /* execute hook if dialect is T-SQL or while restoring babelfish database */
 	    find_coercion_pathway_hook != NULL)
 	{
 		result = find_coercion_pathway_hook(sourceTypeId, targetTypeId, ccontext, funcid);

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -1078,7 +1078,7 @@ func_select_candidate(int nargs,
 	 */
 	if (nunknowns == 0 &&
 	    (sql_dialect == SQL_DIALECT_TSQL ||
-	    (dump_restore && strcmp(dump_restore, "on") == 0)) && /* execute hook if dialect is T-SQL or T-SQL's dump_restore GUC is set */
+	    (dump_restore && strcmp(dump_restore, "on") == 0)) && /* execute hook if dialect is T-SQL or while restoring babelfish database */
 	    func_select_candidate_hook != NULL)
 	{
 		last_candidate = func_select_candidate_hook(nargs, input_typeids, candidates, false);

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -32,6 +32,7 @@
 #include "parser/parse_type.h"
 #include "parser/parser.h"  /* SQL_DIALECT_TSQL */
 #include "utils/builtins.h"
+#include "utils/guc.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
 
@@ -1032,6 +1033,7 @@ func_select_candidate(int nargs,
 	bool		current_is_preferred;
 	bool		slot_has_preferred_type[FUNC_MAX_ARGS];
 	bool		resolved_unknowns;
+	const char	*dump_restore = GetConfigOption("babelfishpg_tsql.dump_restore", true, false);
 
 	/* protect local fixed-size arrays */
 	if (nargs > FUNC_MAX_ARGS)
@@ -1075,7 +1077,8 @@ func_select_candidate(int nargs,
 	 * let's try to choose the best candidate by T-SQL precedence rule.
 	 */
 	if (nunknowns == 0 &&
-	    sql_dialect == SQL_DIALECT_TSQL &&
+	    (sql_dialect == SQL_DIALECT_TSQL ||
+	    (dump_restore && strcmp(dump_restore, "on") == 0)) && /* execute hook if dialect is T-SQL or T-SQL's dump_restore GUC is set */
 	    func_select_candidate_hook != NULL)
 	{
 		last_candidate = func_select_candidate_hook(nargs, input_typeids, candidates, false);


### PR DESCRIPTION
T-SQL has certain different rules and hooks for views
compared to PG and these rules and hooks are only
applicable in T-SQL dialect, that's why MVU fails while
restoring T-SQL views since restore happens in PG dialect.

Fix this by allowing T-SQL specific rules and hooks if
babelfishpg_tsql.dump_restore GUC is set to on.

Task: BABEL-3221
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>