### PR TITLE
Fix MVU failure regarding runtime_error function

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -88,6 +88,41 @@ bbf_selectDumpableCast(CastInfo *cast)
 }
 
 /*
+ * T-SQL allows an empty/space-only string as a default constraint of
+ * NUMERIC column in CREATE TABLE statement. However, it will eventually
+ * throw an error when actual INSERT happens for the default value.
+ *
+ * To support this behavior, we use a function sys.babelfish_runtime_error(),
+ * which raises an error in execution time.
+ *
+ * However, pg_dump evaluates the runtime error function and replaces it with an
+ * error string that causes MVU failure during restore. Hence, we replace the error
+ * string by sys.babelfish_runtime_error() again.
+ */
+char *
+getModifiedDefaultExpr(Archive *fout, const AttrDefInfo attrDefInfo)
+{
+	char *source = attrDefInfo.adef_expr;
+	char *runtimeErrorStr = "'An empty or space-only string cannot be converted into numeric/decimal data type'";
+	char *atttypname;
+
+	if (!isBabelfishDatabase(fout))
+		return source;
+
+	if (!strstr(source, runtimeErrorStr))
+		return source;
+
+	if (attrDefInfo.adnum < 1)
+		return source;
+
+	atttypname = attrDefInfo.adtable->atttypnames[attrDefInfo.adnum - 1];
+	if (strstr(atttypname, "decimal") || strstr(atttypname, "numeric"))
+		return psprintf("(sys.babelfish_runtime_error(%s::text))::integer", runtimeErrorStr);
+
+	return source;
+}
+
+/*
  * fixTsqlTableTypeDependency:
  * Fixes following two types of dependency issues between T-SQL
  * table-type and T-SQL MS-TVF/procedure:

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -22,6 +22,7 @@
 
 
 extern void bbf_selectDumpableCast(CastInfo *cast);
+extern char *getModifiedDefaultExpr(Archive *fout, const AttrDefInfo attrDefInfo);
 extern bool isBabelfishDatabase(Archive *fout);
 extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
 extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -8925,6 +8925,9 @@ getTableAttrs(Archive *fout, TableInfo *tblinfo, int numTables)
 				attrdefs[j].adnum = adnum;
 				attrdefs[j].adef_expr = pg_strdup(PQgetvalue(res, j, 3));
 
+				/* Babelfish-specific logic for default expr */
+				attrdefs[j].adef_expr = getModifiedDefaultExpr(fout, attrdefs[j]);
+
 				attrdefs[j].dobj.name = pg_strdup(tbinfo->dobj.name);
 				attrdefs[j].dobj.namespace = tbinfo->dobj.namespace;
 


### PR DESCRIPTION
T-SQL allows an empty/space-only string as a default constraint of
NUMERIC column in CREATE TABLE statement. However, it will eventually
throw an error when actual INSERT happens for the default value.

To support this behavior, we use a function
sys.babelfish_runtime_error(), which raises an error in execution time.

However, pg_dump evaluates the runtime error function and replaces it
with an error string that causes MVU failure during restore. This commit
replaces the error string by sys.babelfish_runtime_error() again.

Task: BABEL-3234
Signed-off-by: Jungkook Lee <jungkook@amazon.com>