### PR TITLE
Fix MVU failure regarding runtime_error function

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -99,27 +99,23 @@ bbf_selectDumpableCast(CastInfo *cast)
  * error string that causes MVU failure during restore. Hence, we replace the error
  * string by sys.babelfish_runtime_error() again.
  */
-char *
-getModifiedDefaultExpr(Archive *fout, const AttrDefInfo attrDefInfo)
+void
+fixTsqlDefaultExpr(Archive *fout, AttrDefInfo attrDefInfo)
 {
 	char *source = attrDefInfo.adef_expr;
 	char *runtimeErrorStr = "'An empty or space-only string cannot be converted into numeric/decimal data type'";
 	char *atttypname;
 
-	if (!isBabelfishDatabase(fout))
-		return source;
-
-	if (!strstr(source, runtimeErrorStr))
-		return source;
-
-	if (attrDefInfo.adnum < 1)
-		return source;
+	if (!isBabelfishDatabase(fout) || !strstr(source, runtimeErrorStr) || attrDefInfo.adnum < 1)
+		return;
 
 	atttypname = attrDefInfo.adtable->atttypnames[attrDefInfo.adnum - 1];
-	if (strstr(atttypname, "decimal") || strstr(atttypname, "numeric"))
-		return psprintf("(sys.babelfish_runtime_error(%s::text))::integer", runtimeErrorStr);
+	if (!strstr(atttypname, "decimal") && !strstr(atttypname, "numeric"))
+		return;
 
-	return source;
+	/* Replace the default expr to runtime error function */
+	free(source);
+	attrDefInfo.adef_expr = psprintf("(sys.babelfish_runtime_error(%s::text))::integer", runtimeErrorStr);
 }
 
 /*

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -88,6 +88,41 @@ bbf_selectDumpableCast(CastInfo *cast)
 }
 
 /*
+ * T-SQL allows an empty/space-only string as a default constraint of
+ * NUMERIC column in CREATE TABLE statement. However, it will eventually
+ * throw an error when actual INSERT happens for the default value.
+ *
+ * To support this behavior, we use a function sys.babelfish_runtime_error(),
+ * which raises an error in execution time.
+ *
+ * However, pg_dump evaluates the runtime error function and replaces it with an
+ * error string that causes MVU failure during restore. Hence, we replace the error
+ * string by sys.babelfish_runtime_error() again.
+ */
+char *
+getModifiedDefaultExpr(Archive *fout, const AttrDefInfo attrDefInfo)
+{
+	char *source = attrDefInfo.adef_expr;
+	char *runtimeErrorStr = "'An empty or space-only string cannot be converted into numeric/decimal data type'";
+	char *atttypname;
+
+	if (!isBabelfishDatabase(fout))
+		return source;
+
+	if (!strstr(source, runtimeErrorStr))
+		return source;
+
+	if (attrDefInfo.adnum < 1)
+		return source;
+
+	atttypname = attrDefInfo.adtable->atttypnames[attrDefInfo.adnum - 1];
+	if (strstr(atttypname, "decimal") || strstr(atttypname, "numeric"))
+		return psprintf("(sys.babelfish_runtime_error(%s::text))::integer", runtimeErrorStr);
+
+	return source;
+}
+
+/*
  * fixTsqlTableTypeDependency:
  * Fixes following two types of dependency issues between T-SQL
  * table-type and T-SQL MS-TVF/procedure:

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -22,7 +22,7 @@
 
 
 extern void bbf_selectDumpableCast(CastInfo *cast);
-extern char *getModifiedDefaultExpr(Archive *fout, const AttrDefInfo attrDefInfo);
+extern void fixTsqlDefaultExpr(Archive *fout, AttrDefInfo attrDefInfo);
 extern bool isBabelfishDatabase(Archive *fout);
 extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
 extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -22,7 +22,7 @@
 
 
 extern void bbf_selectDumpableCast(CastInfo *cast);
-extern void fixTsqlDefaultExpr(Archive *fout, AttrDefInfo attrDefInfo);
+extern void fixTsqlDefaultExpr(Archive *fout, AttrDefInfo *attrDefInfo);
 extern bool isBabelfishDatabase(Archive *fout);
 extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
 extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -22,6 +22,7 @@
 
 
 extern void bbf_selectDumpableCast(CastInfo *cast);
+extern char *getModifiedDefaultExpr(Archive *fout, const AttrDefInfo attrDefInfo);
 extern bool isBabelfishDatabase(Archive *fout);
 extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
 extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -8926,7 +8926,7 @@ getTableAttrs(Archive *fout, TableInfo *tblinfo, int numTables)
 				attrdefs[j].adef_expr = pg_strdup(PQgetvalue(res, j, 3));
 
 				/* Babelfish-specific logic for default expr */
-				fixTsqlDefaultExpr(fout, attrdefs[j]);
+				fixTsqlDefaultExpr(fout, &attrdefs[j]);
 
 				attrdefs[j].dobj.name = pg_strdup(tbinfo->dobj.name);
 				attrdefs[j].dobj.namespace = tbinfo->dobj.namespace;

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -8925,6 +8925,9 @@ getTableAttrs(Archive *fout, TableInfo *tblinfo, int numTables)
 				attrdefs[j].adnum = adnum;
 				attrdefs[j].adef_expr = pg_strdup(PQgetvalue(res, j, 3));
 
+				/* Babelfish-specific logic for default expr */
+				attrdefs[j].adef_expr = getModifiedDefaultExpr(fout, attrdefs[j]);
+
 				attrdefs[j].dobj.name = pg_strdup(tbinfo->dobj.name);
 				attrdefs[j].dobj.namespace = tbinfo->dobj.namespace;
 

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -8926,7 +8926,7 @@ getTableAttrs(Archive *fout, TableInfo *tblinfo, int numTables)
 				attrdefs[j].adef_expr = pg_strdup(PQgetvalue(res, j, 3));
 
 				/* Babelfish-specific logic for default expr */
-				attrdefs[j].adef_expr = getModifiedDefaultExpr(fout, attrdefs[j]);
+				fixTsqlDefaultExpr(fout, attrdefs[j]);
 
 				attrdefs[j].dobj.name = pg_strdup(tbinfo->dobj.name);
 				attrdefs[j].dobj.namespace = tbinfo->dobj.namespace;


### PR DESCRIPTION
[Engine]

T-SQL allows an empty/space-only string as a default constraint of
NUMERIC column in CREATE TABLE statement. However, it will eventually
throw an error when actual INSERT happens for the default value.

To support this behavior, we use a function
sys.babelfish_runtime_error(), which raises an error in execution time.

However, pg_dump evaluates the runtime error function and replaces it
with an error string that causes MVU failure during restore. This commit
replaces the error string by sys.babelfish_runtime_error() again.

[Extension]

Previously, we built an expression tree using makeFuncExpr() and replaced the default expression. However, the expression tree we made was not the same as a normal function call in PG so pg_get_expr() cannot retrieve the function signature correctly.

This commit adds both COERCE_EXPLICIT_CALL and COERCION_PLPGSQL to the expression tree so pg_get_expr() can understand and retrieve the runtime error function correctly. Also, it adds a minor fix on BABEL-3190-prepare test case because BABEL_1_X_DEV cannot handle the same table name properly in multi-db mode.

Task: BABEL-3234
Signed-off-by: Jungkook Lee <jungkook@amazon.com>