### PR TITLE
Support pg_upgrade for TSQL triggers

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -115,7 +115,7 @@ static void set_iot_state(Oid relid, CmdType cmdType, IOTState newState);
 */
 static bool IsCompositeTriggerActive(void);
 static void AddCompositeTriggerLevelData(void);
-static bool IsCompositeTrigger(Oid fn_oid);
+static bool IsCompositeTrigger(Oid fn_oid, List *fn_name);
 
 
 /*
@@ -219,6 +219,9 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 	bool		trigger_exists = false;
 	Oid			existing_constraint_oid = InvalidOid;
 	bool		existing_isInternal = false;
+	bool		is_composite_trigger = false;
+
+	is_composite_trigger = IsCompositeTrigger(funcoid, stmt->funcname);
 
 	if (OidIsValid(relOid))
 		rel = table_open(relOid, ShareRowExclusiveLock);
@@ -233,7 +236,7 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 	{
 		/* Tables can't have INSTEAD OF triggers */
 		/* BABELFISH: Support Instead of triggers, lift restriction for TSQL */
-		if (sql_dialect != SQL_DIALECT_TSQL &&
+		if (!is_composite_trigger &&
 			stmt->timing != TRIGGER_TYPE_BEFORE &&
 			stmt->timing != TRIGGER_TYPE_AFTER)
 			ereport(ERROR,
@@ -246,7 +249,7 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 	{
 		/* Partitioned tables can't have INSTEAD OF triggers */
 		/* BABELFISH: Support Instead of triggers, lift restriction for TSQL */
-		if (sql_dialect != SQL_DIALECT_TSQL &&
+		if (!is_composite_trigger &&
 			stmt->timing != TRIGGER_TYPE_BEFORE &&
 			stmt->timing != TRIGGER_TYPE_AFTER)
 			ereport(ERROR,
@@ -406,11 +409,11 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 	/* INSTEAD triggers must be row-level, and can't have WHEN or columns */
 	if (TRIGGER_FOR_INSTEAD(tgtype))
 	{
-		if (sql_dialect != SQL_DIALECT_TSQL && !TRIGGER_FOR_ROW(tgtype))
+		if (!is_composite_trigger && !TRIGGER_FOR_ROW(tgtype))
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					errmsg("INSTEAD OF triggers must be FOR EACH ROW")));
-		if (sql_dialect == SQL_DIALECT_TSQL && TRIGGER_FOR_ROW(tgtype))
+		if (is_composite_trigger && TRIGGER_FOR_ROW(tgtype))
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					errmsg("INSTEAD OF triggers not supported for FOR EACH ROW with TSQL dialect")));
@@ -494,7 +497,7 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 							 errmsg("ROW triggers with transition tables are not supported on inheritance children")));
 			}
 
-			if (sql_dialect != SQL_DIALECT_TSQL && stmt->timing != TRIGGER_TYPE_AFTER)
+			if (!is_composite_trigger && stmt->timing != TRIGGER_TYPE_AFTER)
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
 						 errmsg("transition table name can only be specified for an AFTER trigger")));
@@ -521,7 +524,7 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 			if ((((TRIGGER_FOR_INSERT(tgtype) ? 1 : 0) +
 				 (TRIGGER_FOR_UPDATE(tgtype) ? 1 : 0) +
 				 (TRIGGER_FOR_DELETE(tgtype) ? 1 : 0)) != 1) 
-				 && sql_dialect != SQL_DIALECT_TSQL)
+				 && !is_composite_trigger)
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("transition tables cannot be specified for triggers with more than one event")));
@@ -548,7 +551,7 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 
 			if (tt->isNew)
 			{
-				if (sql_dialect == SQL_DIALECT_TSQL){
+				if (is_composite_trigger){
 					if (!(TRIGGER_FOR_DELETE(tgtype) ||
 						TRIGGER_FOR_UPDATE(tgtype) ||
 						TRIGGER_FOR_INSERT(tgtype)))
@@ -571,7 +574,7 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 			}
 			else
 			{
-				if (sql_dialect != SQL_DIALECT_TSQL) {
+				if (!is_composite_trigger) {
 					if (!(TRIGGER_FOR_DELETE(tgtype) ||
 						TRIGGER_FOR_UPDATE(tgtype)))
 						ereport(ERROR,
@@ -910,7 +913,7 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 		* enforce unique trigger names in order to do the same.
 		* TODO: This can be done using a new hook. 
 		*/
-		if(sql_dialect == SQL_DIALECT_TSQL)
+		if(is_composite_trigger)
 		{
 			ScanKeyInit(&key,
 						Anum_pg_trigger_tgname,
@@ -6309,7 +6312,7 @@ AfterTriggerSaveEvent(EState *estate, ResultRelInfo *relinfo,
 		 * trigger data list
 		 */
 		if (compositeTriggers.triggerLevel > 0 &&
-			IsCompositeTrigger(trigger->tgfoid))
+			IsCompositeTrigger(trigger->tgfoid, NULL))
 		{
 			MemoryContext oldCxt = MemoryContextSwitchTo(compositeTriggers.curCxt);
 			MemoryContext oldEventCxt = afterTriggers.event_cxt;
@@ -6613,39 +6616,24 @@ void EndCompositeTriggers(bool error)
  * Find if the trigger is TSQL or PG type
  */
 static
-bool IsCompositeTrigger(Oid fn_oid)
+bool IsCompositeTrigger(Oid fn_oid, List *fn_name)
 {
 	bool	isComposite = false;
 	Oid		pltsql_lang_oid = InvalidOid;
 	Oid		pltsql_validator_oid = InvalidOid;
-	/*
-	 * FIXME: the following typedef (PLtsql_config) describes a
-	 * structure shared with PLtsql.  Since the type is shared,
-	 * we should find a header file that is properly shared and
-	 * move this typedef
-	 *
-	 * This typedef *must* be kept in-synch with the PLtsql_config
-	 * type declaration found in contrib/babelfishpg_tsql/src/pgtsql.h
-	 */
-	typedef struct PLtsql_config
-	{
-		char	*version;         /* Extension version info */
-		Oid		 handler_oid;     /* Oid of language handler function */
-		Oid		 validator_oid;   /* Oid of language validator function */
-	} PLtsql_config;
 
-	PLtsql_config **config = (PLtsql_config **) find_rendezvous_variable("PLtsql_config");
-
-	if (*config)
-	{
-		pltsql_lang_oid = (*config)->handler_oid;
-		pltsql_validator_oid = (*config)->validator_oid;
-	}
+	if (get_func_language_oids_hook)
+		get_func_language_oids_hook(&pltsql_lang_oid, &pltsql_validator_oid);
 
 	if (pltsql_lang_oid != InvalidOid)
 	{
 		HeapTuple	tuple;
 		Form_pg_proc procedureStruct;
+		/* If function oid is invalid, get it using function name */
+		if (!OidIsValid(fn_oid) && fn_name != NULL)
+		{
+			fn_oid = LookupFuncName(fn_name, 0, NULL, false);
+		}
 		tuple = SearchSysCache1(PROCOID, fn_oid);
 		if (!HeapTupleIsValid(tuple))
 			elog(ERROR, "cache lookup failed for trigger %u", fn_oid);

--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -772,9 +772,12 @@ typedef void (*fmgr_hook_type) (FmgrHookEventType event,
 
 typedef void (*non_tsql_proc_entry_hook_type) (int, int);
 
+typedef void (*get_func_language_oids_hook_type)(Oid *, Oid *);
+
 extern PGDLLIMPORT needs_fmgr_hook_type needs_fmgr_hook;
 extern PGDLLIMPORT fmgr_hook_type fmgr_hook;
 extern PGDLLIMPORT non_tsql_proc_entry_hook_type non_tsql_proc_entry_hook;
+extern PGDLLIMPORT get_func_language_oids_hook_type get_func_language_oids_hook;
 
 #define FmgrHookIsNeeded(fn_oid)							\
 	(!needs_fmgr_hook ? false : (*needs_fmgr_hook)(fn_oid))


### PR DESCRIPTION
TSQL triggers supports more features and feature combinations when
compared to PG triggers. This is implemented using TSQL dialect check
when running triggers DDLs. During restore, TSQL triggers are created with
PG dialect and they error out due to not supported features/combinations
in PG.

As a fix, create trigger will rely on trigger function language
(TSQL vs PG) instead of dialect to support TSQL features. This will
work for trigger creation in all cases including restore.

Task : BABEL-3249

Signed-off-by: Surendra Vishnoi <vishnosu@amazon.com>