### PR TITLE
Fix a syntax error to set attoptions bbf_original_name having a special character

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -251,11 +251,14 @@ void fixAttoptionsBbfOriginalName(Archive *fout, char **attoptions)
 {
 	PGresult *res;
 	PQExpBuffer q;
-	int temp_buf_len;
-	unsigned char *temp_buf;
 
 	q = createPQExpBuffer();
 
+	/*
+	 * As attoptions can be a list of options,
+	 * we will split options first, make them as an array, find an option starting with 'bbf_original_name',
+	 * enclose its value with single quotes, and aggregate all array elements into a single string.
+	 */
 	appendPQExpBuffer(q,
 		"SELECT substring(options, 2, length(options)-2) as new_options FROM ( "
 		"SELECT array_agg( "

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -252,6 +252,9 @@ void fixAttoptionsBbfOriginalName(Archive *fout, char **attoptions)
 	PGresult *res;
 	PQExpBuffer q;
 
+	if (!isBabelfishDatabase(fout))
+		return;
+
 	q = createPQExpBuffer();
 
 	/*

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -26,6 +26,7 @@ extern bool isBabelfishDatabase(Archive *fout);
 extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
 extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);
 extern int getTsqlTvfType(Archive *fout, const FuncInfo *finfo, char prokind, bool proretset);
+extern void fixAttoptionsBbfOriginalName(Archive *fout, char **attoptions);
 extern void setOrResetPltsqlFuncRestoreGUCs(Archive *fout, PQExpBuffer q, const FuncInfo *finfo, char prokind, bool proretset, bool is_set);
 
 #endif

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -16481,10 +16481,14 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 			 * Dump per-column attributes.
 			 */
 			if (tbinfo->attoptions[j][0] != '\0')
+			{
+				fixAttoptionsBbfOriginalName(fout, &tbinfo->attoptions[j]);
+
 				appendPQExpBuffer(q, "ALTER %sTABLE ONLY %s ALTER COLUMN %s SET (%s);\n",
 								  foreign, qualrelname,
 								  fmtId(tbinfo->attnames[j]),
 								  tbinfo->attoptions[j]);
+			}
 
 			/*
 			 * Dump per-column fdw options.


### PR DESCRIPTION
Fix a syntax error to set attoptions bbf_original_name having a special character

Babelfish keeps an column original name in attoptions field in pg_atrribute.
If special chracter is involved, as pg_dump generates an ALTER TABLE
ALTER COLUMN SET without any escaping, it can cause an error.

To prevent this issue, when generating ALTER statement, enclose column
original name with single quotes so that original name can be treated as
a string literal. This single quotes will be stripped out by parser so
attoptions stores the original name without quotes. So this will not
break backward-compatibility.

Task: BABEL-3121
Signed-off-by: Sangil Song sonsangi@amazon.co