### PR TITLE
Fix + and / operators during pg_upgrade

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -209,8 +209,8 @@ fixOprRegProc(Archive *fout,
 	if (!isBabelfishDatabase(fout) || fout->remoteVersion >= 140000)
 		return;
 
-	nsname = fmtId(oprinfo->dobj.namespace->dobj.name);
-	if (strcmp(nsname, "\"sys\"") != 0)
+	nsname = oprinfo->dobj.namespace->dobj.name;
+	if (strcmp(nsname, "sys") != 0)
 		return;
 
 	oprname = oprinfo->dobj.name;

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -191,6 +191,57 @@ fixTsqlTableTypeDependency(Archive *fout, DumpableObject *dobj, DumpableObject *
 }
 
 /*
+ * In Babelfish v1.2, we redefined some operators to fix issues.
+ * However, we cannot replace those operators using upgrade scripts
+ * because customer-defined objects can depend on the operators.
+ * This function will do in-place substitutions as a part of pg_dump.
+ */
+void
+fixOprRegProc(Archive *fout,
+			  const OprInfo *oprinfo,
+			  const char *oprleft,
+			  const char *oprright,
+			  char **oprregproc)
+{
+	const char *nsname;
+	const char *oprname;
+
+	if (!isBabelfishDatabase(fout) || fout->remoteVersion >= 140000)
+		return;
+
+	nsname = fmtId(oprinfo->dobj.namespace->dobj.name);
+	if (strcmp(nsname, "\"sys\"") != 0)
+		return;
+
+	oprname = oprinfo->dobj.name;
+	if (strcmp(oprname, "+") == 0 &&
+		strcmp(oprleft, "\"text\"") == 0 &&
+		strcmp(oprright, "\"text\"") == 0)
+	{
+		free(*oprregproc);
+		*oprregproc = pg_strdup("\"sys\".\"babelfish_concat_wrapper_outer\"");
+	}
+	else if (strcmp(oprname, "/") == 0 && strcmp(oprright, "\"sys\".\"fixeddecimal\"") == 0)
+	{
+		if (strcmp(oprleft, "bigint") == 0)
+		{
+			free(*oprregproc);
+			*oprregproc = pg_strdup("\"sys\".\"int8fixeddecimaldiv_money\"");
+		}
+		else if (strcmp(oprleft, "integer") == 0)
+		{
+			free(*oprregproc);
+			*oprregproc = pg_strdup("\"sys\".\"int4fixeddecimaldiv_money\"");
+		}
+		else if (strcmp(oprleft, "smallint") == 0)
+		{
+			free(*oprregproc);
+			*oprregproc = pg_strdup("\"sys\".\"int2fixeddecimaldiv_money\"");
+		}
+	}
+}
+
+/*
  * isTsqlTableType:
  * Returns true if given table is a template table for
  * underlying T-SQL table-type, false otherwise.

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -24,6 +24,7 @@
 extern void bbf_selectDumpableCast(CastInfo *cast);
 extern void fixTsqlDefaultExpr(Archive *fout, AttrDefInfo *attrDefInfo);
 extern bool isBabelfishDatabase(Archive *fout);
+extern void fixOprRegProc(Archive *fout, const OprInfo *oprinfo, const char *oprleft, const char *oprright, char **oprregproc);
 extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
 extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);
 extern int getTsqlTvfType(Archive *fout, const FuncInfo *finfo, char prokind, bool proretset);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -12964,6 +12964,9 @@ dumpOpr(Archive *fout, const OprInfo *oprinfo)
 	oprregproc = convertRegProcReference(oprcode);
 	if (oprregproc)
 	{
+		/* Special handling for Babelfish */
+		fixOprRegProc(fout, oprinfo, oprleft, oprright, &oprregproc);
+
 		appendPQExpBuffer(details, "    FUNCTION = %s", oprregproc);
 		free(oprregproc);
 	}


### PR DESCRIPTION
[Engine]

In Babelfish v1.2, we had to re-define some operators to fix issues.
However, we were not able to apply the fix in the upgrade script because
customer-defined object may have depended on those operators.

This commit introduces a fix by doing it during pg_upgrade.

[Extension]

As this issue can only be tested when a user initiates Major Version
Upgrade from Babelfish v1.0 or v1.1, added a temporary test case
manipulating pg_operator directly. Once we have a Github action that can
test MVU from v1.0, we should remove this test case to avoid
side-effects to other test cases.

Task: BABEL-3112
Signed-off-by: Jungkook Lee <jungkook@amazon.com>