### PR TITLE
Add reverse dependency between TSQL trigger and trigger function during restore

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -1164,6 +1164,15 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 	referenced.objectSubId = 0;
 	recordDependencyOn(&myself, &referenced, DEPENDENCY_NORMAL);
 
+	/*
+	 * For composite triggers, add dependency from trigger function
+	 * to trigger so that a drop trigger will result in cascade drop
+	 * for function as well. Trigger functions are created as part of
+	 * create trigger for composite triggers.
+	 */
+	if (is_composite_trigger)
+		recordDependencyOn(&referenced, &myself, DEPENDENCY_NORMAL);
+
 	if (isInternal && OidIsValid(constraintOid))
 	{
 		/*


### PR DESCRIPTION
TSQL triggers needs reverse dependency from trigger function to
trigger. It helps in dropping function when trigger itself is dropped
as trigger functions are internal to TSQL triggers. This dependency
is added specifically for TSQL triggers only.

During restore, TSQL triggers are restored using two parts, first function
restore followed by trigger restore using PG semantics. This code path
does not execute TSQL logic to add reverse dependency. As a fix, we have
moved reverse dependency addition to a place which executes during both
normal trigger creation and restore.

Task: BABEL-3249

Signed-off-by: Surendra Vishnoi <vishnosu@amazon.com>