### PR TITLE
BABEL: Check_or_set_default_typmod_hook should be called for ALTER TABLE ADD COLUMN and ALTER TABLE ALTER COLUMN

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6872,6 +6872,9 @@ ATExecAddColumn(List **wqueue, AlteredTableInfo *tab, Relation rel,
 					   list_make1_oid(rel->rd_rel->reltype),
 					   0);
 
+	if (sql_dialect == SQL_DIALECT_TSQL && check_or_set_default_typmod_hook)
+		(*check_or_set_default_typmod_hook)(colDef->typeName, &typmod, false);
+
 	/*
 	 * Construct new attribute's pg_attribute entry.  (Variable-length fields
 	 * are handled by InsertPgAttributeTuples().)
@@ -12203,6 +12206,9 @@ ATPrepAlterColumnType(List **wqueue,
 	/* And the collation */
 	targetcollid = GetColumnDefCollation(NULL, def, targettype);
 
+	if (sql_dialect == SQL_DIALECT_TSQL && check_or_set_default_typmod_hook)
+		(*check_or_set_default_typmod_hook)(typeName, &targettypmod, false);
+
 	/* make sure datatype is legal for a column */
 	CheckAttributeType(colName, targettype, targetcollid,
 					   list_make1_oid(rel->rd_rel->reltype),
@@ -12522,6 +12528,9 @@ ATExecAlterColumnType(AlteredTableInfo *tab, Relation rel,
 	targettype = tform->oid;
 	/* And the collation */
 	targetcollid = GetColumnDefCollation(NULL, def, targettype);
+
+	if (sql_dialect == SQL_DIALECT_TSQL && check_or_set_default_typmod_hook)
+		(*check_or_set_default_typmod_hook)(typeName, &targettypmod, false);
 
 	/*
 	 * If there is a default expression for the column, get it and ensure we


### PR DESCRIPTION
Previously, check_or_set_default_typmod_hook was not being called for ALTER TABLE ADD/ALTER COLUMN, which will cause typmod to be -1 and cause an issue when we send data from TDS layer.

This commit fixes the problem by calling the appropriate hook for affected ALTER TABLE command which will set the correct typmod.

Task: BABEL-2604
Author: Dipesh Dhameliya <dddhamel@amazon.com>
Signed-off-by: Sharu Goel <goelshar@amazon.com>
(cherry picked from commit 9986eda161e7b60bf949ba30b28e285b18824924)