### PR TITLE
BABEL: Support sys.dm_exec_sessions and sys.dm_exec_connections dynam…

### DIFF
--- a/src/backend/utils/activity/pgstat.c
+++ b/src/backend/utils/activity/pgstat.c
@@ -177,6 +177,9 @@ static void pgstat_build_snapshot_fixed(PgStat_Kind kind);
 
 static inline bool pgstat_is_kind_valid(int ikind);
 
+invalidate_stat_table_hook_type invalidate_stat_table_hook = NULL;
+guc_newval_hook_type guc_newval_hook = NULL;
+
 
 /* ----------
  * GUC parameters
@@ -773,6 +776,13 @@ pgstat_clear_snapshot(void)
 	 * forward the reset request.
 	 */
 	pgstat_clear_backend_activity_snapshot();
+
+	/*
+	 * Signal babelfishpg_tds extension (if loaded) to
+	 * mark the local TDS status table as invalid too
+	 */
+	if (invalidate_stat_table_hook)
+		(*invalidate_stat_table_hook)();
 }
 
 void *

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -258,7 +258,6 @@ static bool check_wal_consistency_checking_deferred = false;
 
 guc_push_old_value_hook_type guc_push_old_value_hook = NULL;
 validate_set_config_function_hook_type validate_set_config_function_hook = NULL;
-guc_newval_hook_type guc_newval_hook = NULL;
 
 /*
  * Options for enum values defined in this module.

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -705,4 +705,13 @@ extern void write_structdef_file(void);
 typedef void (*pre_function_call_hook_type) (const char *funcName);
 extern PGDLLIMPORT pre_function_call_hook_type pre_function_call_hook;
 
+typedef void (*invalidate_stat_table_hook_type) (void);
+extern PGDLLIMPORT invalidate_stat_table_hook_type invalidate_stat_table_hook;
+
+typedef void (*guc_newval_hook_type) (const char *guc, bool boolVal, const char *strVal, int intVal);
+extern PGDLLIMPORT guc_newval_hook_type guc_newval_hook;
+
+typedef bool (*tsql_has_pgstat_permissions_hook_type) (Oid role);
+extern PGDLLIMPORT tsql_has_pgstat_permissions_hook_type tsql_has_pgstat_permissions_hook;
+
 #endif							/* PGSTAT_H */


### PR DESCRIPTION
…ic management view

This commit adds three hooks:
1. pgstat_clear_snapshot_hook: Signals the TDS extension to invalidate its local status copy when the engine invalidates its local copy.
2. guc_newval_hook: Signals the TDS extension that a GUC defined in the engine has changed value.
3. tsql_perm_hook: Checks to see if the current session user is sysadmin or is trying to access info of its own session.

Task: BABEL-1887/2296
Author: Sharu Goel <goelshar@amazon.com>
Signed-off-by: Xiaohui Fanhe <hexiaohu@amazon.com>
(cherry picked from commit 110e698bf7b3e133b0a8fe2089fc653b057abb68)