### PR TITLE
BABEL: Support CHECKSUM(*) and CHECKSUM(c1, c2, ...)

### DIFF
--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -17,6 +17,7 @@
 
 #include "catalog/pg_aggregate.h"
 #include "catalog/pg_proc.h"
+#include "catalog/namespace.h"
 #include "catalog/pg_type.h"
 #include "commands/dbcommands.h"
 #include "miscadmin.h"
@@ -102,6 +103,7 @@ static Expr *make_distinct_op(ParseState *pstate, List *opname,
 							  Node *ltree, Node *rtree, int location);
 static Node *make_nulltest_from_distinct(ParseState *pstate,
 										 A_Expr *distincta, Node *arg);
+static List *ExpandChecksumStar(ParseState *pstate, FuncCall *fn, int location);
 
 lookup_param_hook_type lookup_param_hook = NULL;
 /*
@@ -1474,6 +1476,8 @@ transformFuncCall(ParseState *pstate, FuncCall *fn)
 	Node	   *last_srf = pstate->p_last_srf;
 	List	   *targs;
 	ListCell   *args;
+      char *schemaname;
+      char *functionname;
 
 	/* Transform the list of arguments ... */
 	targs = NIL;
@@ -1502,6 +1506,20 @@ transformFuncCall(ParseState *pstate, FuncCall *fn)
 												 EXPR_KIND_ORDER_BY));
 		}
 	}
+        
+      DeconstructQualifiedName(fn->funcname, &schemaname, &functionname);
+
+      /* Firstly, we check whether the schema name is null or 'sys'.
+       * When the function name is checksum, we check if the argument is '*',
+       * if yes, then we traverse the table and get the column names from the
+       * table. We replace the argument '*' with the list of column names.
+       */
+
+      if (!schemaname || (strlen(schemaname) == 3 && strncmp(schemaname, "sys", 3) == 0))
+              if (strlen(functionname) == 8 &&
+                          strncmp(functionname, "checksum", 8) == 0 &&
+                          fn->agg_star == true)
+                      targs = ExpandChecksumStar(pstate, fn, fn->location);
 
 	/* ... and hand off to ParseFuncOrColumn */
 	return ParseFuncOrColumn(pstate,
@@ -4661,4 +4679,18 @@ transformJsonSerializeExpr(ParseState *pstate, JsonSerializeExpr *expr)
 
 	return makeJsonConstructorExpr(pstate, JSCTOR_JSON_SERIALIZE, list_make1(arg),
 								   NULL, returning, false, false, expr->location);
+
+// Expands checksum(*) to checksum(c1, c2, ...)
+List *
+ExpandChecksumStar(ParseState *pstate, FuncCall *fn, int location)
+{
+        List      *target = NIL;
+        ListCell   *lc;
+        foreach(lc, pstate->p_namespace)
+        {
+                ParseNamespaceItem *nsitem = (ParseNamespaceItem *) lfirst(lc);
+                target = list_concat(target, expandNSItemVars(nsitem, 0, location, NULL));
+        }
+        fn->agg_star = false;
+        return target;
 }

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -1476,8 +1476,8 @@ transformFuncCall(ParseState *pstate, FuncCall *fn)
 	Node	   *last_srf = pstate->p_last_srf;
 	List	   *targs;
 	ListCell   *args;
-      char *schemaname;
-      char *functionname;
+	char	   *schemaname;
+	char	   *functionname;
 
 	/* Transform the list of arguments ... */
 	targs = NIL;
@@ -4679,6 +4679,7 @@ transformJsonSerializeExpr(ParseState *pstate, JsonSerializeExpr *expr)
 
 	return makeJsonConstructorExpr(pstate, JSCTOR_JSON_SERIALIZE, list_make1(arg),
 								   NULL, returning, false, false, expr->location);
+}
 
 // Expands checksum(*) to checksum(c1, c2, ...)
 List *


### PR DESCRIPTION
Added a new function to expand checksum(*).
While transforming the function call, we are checking if it's a checksum function. If yes, we are expanding '*' to column names of that respective tables.

Task: BABEL-2626
Author: Shalini Lohia <lshalini@amazon.com>
Signed-off-by: Xiaohui Fanhe <hexiaohu@amazon.com>
(cherry picked from commit 5dcba4b0aa2a426995cb8d698e6ac9b5be88a052)