### PR TITLE
BABEL: Handle ROWVERSION/TIMESTAMP columns for Postgres Logical Replication

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -41,6 +41,8 @@
 #include "utils/rel.h"
 #include "utils/rls.h"
 
+is_tsql_rowversion_or_timestamp_datatype_hook_type is_tsql_rowversion_or_timestamp_datatype_hook = NULL;
+
 /*
  *	 DoCopy executes the SQL COPY statement
  *
@@ -730,6 +732,10 @@ CopyGetAttnums(TupleDesc tupDesc, Relation rel, List *attnamelist)
 				continue;
 			if (TupleDescAttr(tupDesc, i)->attgenerated)
 				continue;
+			/* Skip TSQL ROWVERSION/TIMESTAMP column if it exists */
+			if (is_tsql_rowversion_or_timestamp_datatype_hook &&
+				is_tsql_rowversion_or_timestamp_datatype_hook(TupleDescAttr(tupDesc, i)->atttypid))
+				continue;
 			attnums = lappend_int(attnums, i + 1);
 		}
 	}
@@ -760,6 +766,13 @@ CopyGetAttnums(TupleDesc tupDesc, Relation rel, List *attnamelist)
 								 errmsg("column \"%s\" is a generated column",
 										name),
 								 errdetail("Generated columns cannot be used in COPY.")));
+					if (is_tsql_rowversion_or_timestamp_datatype_hook &&
+						is_tsql_rowversion_or_timestamp_datatype_hook(att->atttypid))
+						ereport(ERROR,
+								(errcode(ERRCODE_INVALID_COLUMN_REFERENCE),
+								 errmsg("column \"%s\" is a ROWVERSION/TIMESTAMP column",
+								 		name),
+								 errdetail("ROWVERSION/TIMESTAMP columns cannot be used in COPY.")));
 					attnum = att->attnum;
 					break;
 				}

--- a/src/backend/replication/logical/proto.c
+++ b/src/backend/replication/logical/proto.c
@@ -13,6 +13,7 @@
 #include "postgres.h"
 
 #include "access/sysattr.h"
+#include "commands/copy.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_type.h"
 #include "libpq/pqformat.h"
@@ -783,6 +784,11 @@ logicalrep_write_tuple(StringInfo out, Relation rel, TupleTableSlot *slot,
 		if (att->attisdropped || att->attgenerated)
 			continue;
 
+		/* Skip TSQL ROWVERSION/TIMESTAMP column if it exists */
+		if (is_tsql_rowversion_or_timestamp_datatype_hook &&
+			is_tsql_rowversion_or_timestamp_datatype_hook(TupleDescAttr(desc, i)->atttypid))
+			continue;
+
 		if (!column_in_column_list(att->attnum, columns))
 			continue;
 
@@ -802,6 +808,11 @@ logicalrep_write_tuple(StringInfo out, Relation rel, TupleTableSlot *slot,
 		Form_pg_attribute att = TupleDescAttr(desc, i);
 
 		if (att->attisdropped || att->attgenerated)
+			continue;
+
+		/* Skip TSQL ROWVERSION/TIMESTAMP column if it exists */
+		if (is_tsql_rowversion_or_timestamp_datatype_hook &&
+			is_tsql_rowversion_or_timestamp_datatype_hook(att->atttypid))
 			continue;
 
 		if (!column_in_column_list(att->attnum, columns))
@@ -946,6 +957,11 @@ logicalrep_write_attrs(StringInfo out, Relation rel, Bitmapset *columns)
 		if (att->attisdropped || att->attgenerated)
 			continue;
 
+		/* Skip TSQL ROWVERSION/TIMESTAMP column if it exists */
+		if (is_tsql_rowversion_or_timestamp_datatype_hook &&
+			is_tsql_rowversion_or_timestamp_datatype_hook(TupleDescAttr(desc, i)->atttypid))
+			continue;
+
 		if (!column_in_column_list(att->attnum, columns))
 			continue;
 
@@ -965,6 +981,11 @@ logicalrep_write_attrs(StringInfo out, Relation rel, Bitmapset *columns)
 		uint8		flags = 0;
 
 		if (att->attisdropped || att->attgenerated)
+			continue;
+
+		/* Skip TSQL ROWVERSION/TIMESTAMP column if it exists */
+		if (is_tsql_rowversion_or_timestamp_datatype_hook &&
+			is_tsql_rowversion_or_timestamp_datatype_hook(att->atttypid))
 			continue;
 
 		if (!column_in_column_list(att->attnum, columns))

--- a/src/backend/replication/logical/relation.c
+++ b/src/backend/replication/logical/relation.c
@@ -18,6 +18,7 @@
 #include "postgres.h"
 
 #include "access/table.h"
+#include "commands/copy.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_subscription_rel.h"
 #include "executor/executor.h"
@@ -413,7 +414,9 @@ logicalrep_rel_open(LogicalRepRelId remoteid, LOCKMODE lockmode)
 			int			attnum;
 			Form_pg_attribute attr = TupleDescAttr(desc, i);
 
-			if (attr->attisdropped || attr->attgenerated)
+			if (attr->attisdropped || attr->attgenerated ||
+				(is_tsql_rowversion_or_timestamp_datatype_hook &&
+				is_tsql_rowversion_or_timestamp_datatype_hook(attr->atttypid)))
 			{
 				entry->attrmap->attnums[i] = -1;
 				continue;

--- a/src/backend/replication/logical/tablesync.c
+++ b/src/backend/replication/logical/tablesync.c
@@ -909,6 +909,10 @@ fetch_remote_table_info(char *nspname, char *relname,
 		lrel->atttyps[natt] = DatumGetObjectId(slot_getattr(slot, 3, &isnull));
 		Assert(!isnull);
 
+		if (is_tsql_rowversion_or_timestamp_datatype_hook &&
+			is_tsql_rowversion_or_timestamp_datatype_hook(lrel->atttyps[natt]))
+			continue;
+
 		if (DatumGetBool(slot_getattr(slot, 4, &isnull)))
 			lrel->attkeys = bms_add_member(lrel->attkeys, natt);
 

--- a/src/backend/replication/logical/worker.c
+++ b/src/backend/replication/logical/worker.c
@@ -135,6 +135,7 @@
 #include "access/twophase.h"
 #include "access/xact.h"
 #include "access/xlog_internal.h"
+#include "commands/extension.h"
 #include "catalog/catalog.h"
 #include "catalog/indexing.h"
 #include "catalog/namespace.h"
@@ -143,6 +144,7 @@
 #include "catalog/pg_subscription.h"
 #include "catalog/pg_subscription_rel.h"
 #include "catalog/pg_tablespace.h"
+#include "commands/copy.h"
 #include "commands/tablecmds.h"
 #include "commands/tablespace.h"
 #include "commands/trigger.h"
@@ -197,6 +199,8 @@
 #include "utils/timeout.h"
 
 #define NAPTIME_PER_CYCLE 1000	/* max sleep time between cycles (1s) */
+
+logicalrep_modify_slot_hook_type logicalrep_modify_slot_hook = NULL;
 
 typedef struct FlushPosition
 {
@@ -1849,6 +1853,15 @@ apply_handle_update(StringInfo s)
 					bms_add_member(target_rte->updatedCols,
 								   i + 1 - FirstLowInvalidHeapAttributeNumber);
 		}
+		/* Add TSQL ROWVERSION/TIMESTAMP column to updatedCols */
+		else if (!att->attisdropped && !att->attgenerated &&
+			is_tsql_rowversion_or_timestamp_datatype_hook &&
+			is_tsql_rowversion_or_timestamp_datatype_hook(att->atttypid))
+		{
+			target_rte->updatedCols =
+				bms_add_member(target_rte->updatedCols,
+							   i + 1 - FirstLowInvalidHeapAttributeNumber);
+		}
 	}
 
 	/* Also populate extraUpdatedCols, in case we have generated columns */
@@ -1915,6 +1928,9 @@ apply_handle_update_internal(ApplyExecutionData *edata,
 		/* Process and store remote tuple in the slot */
 		oldctx = MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));
 		slot_modify_data(remoteslot, localslot, relmapentry, newtup);
+		/* Fill TSQL ROWVERSION/TIMESTAMP column if it exists */
+		if (logicalrep_modify_slot_hook)
+			logicalrep_modify_slot_hook(localrel, estate, remoteslot);
 		MemoryContextSwitchTo(oldctx);
 
 		EvalPlanQualSetSlot(&epqstate, remoteslot);
@@ -2232,6 +2248,9 @@ apply_handle_tuple_routing(ApplyExecutionData *edata,
 				oldctx = MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));
 				slot_modify_data(remoteslot_part, localslot, part_entry,
 								 newtup);
+				/* Fill TSQL ROWVERSION/TIMESTAMP column if it exists */
+				if (logicalrep_modify_slot_hook)
+					logicalrep_modify_slot_hook(partrel, estate, remoteslot_part);
 				MemoryContextSwitchTo(oldctx);
 
 				/*
@@ -3579,6 +3598,8 @@ ApplyWorkerMain(Datum main_arg)
 	char	   *myslotname = NULL;
 	WalRcvStreamOptions options;
 	int			server_version;
+	const char*	pgtsql_library_name = "babelfishpg_tsql";
+	const char*	pgtsql_common_library_name = "babelfishpg_common";
 
 	/* Attach to slot */
 	logicalrep_worker_attach(worker_slot);
@@ -3608,6 +3629,21 @@ ApplyWorkerMain(Datum main_arg)
 	BackgroundWorkerInitializeConnectionByOid(MyLogicalRepWorker->dbid,
 											  MyLogicalRepWorker->userid,
 											  0);
+
+	/* load babelfishpg_tsql library if exists. */
+	StartTransactionCommand();
+	PushActiveSnapshot(GetTransactionSnapshot());
+	if (get_extension_oid(pgtsql_library_name, true) != InvalidOid)
+	{
+		/*
+		 * babelfishpg_tsql extension depends on babelfishpg_common, so
+		 * babelfishpg_common must be loaded first.
+		 */
+		load_libraries(pgtsql_common_library_name, NULL, false);
+		load_libraries(pgtsql_library_name, NULL, false);
+	}
+	PopActiveSnapshot();
+	CommitTransactionCommand();
 
 	/*
 	 * Set always-secure search path, so malicious users can't redirect user

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -97,4 +97,6 @@ extern uint64 DoCopyTo(CopyToState cstate);
 extern List *CopyGetAttnums(TupleDesc tupDesc, Relation rel,
 							List *attnamelist);
 
+typedef bool (*is_tsql_rowversion_or_timestamp_datatype_hook_type)(Oid oid);
+extern PGDLLIMPORT is_tsql_rowversion_or_timestamp_datatype_hook_type is_tsql_rowversion_or_timestamp_datatype_hook;
 #endif							/* COPY_H */

--- a/src/include/replication/logical.h
+++ b/src/include/replication/logical.h
@@ -11,8 +11,10 @@
 
 #include "access/xlog.h"
 #include "access/xlogreader.h"
+#include "nodes/execnodes.h"
 #include "replication/output_plugin.h"
 #include "replication/slot.h"
+#include "utils/relcache.h"
 
 struct LogicalDecodingContext;
 
@@ -143,5 +145,8 @@ extern bool filter_prepare_cb_wrapper(LogicalDecodingContext *ctx,
 extern bool filter_by_origin_cb_wrapper(LogicalDecodingContext *ctx, RepOriginId origin_id);
 extern void ResetLogicalStreamingState(void);
 extern void UpdateDecodingStats(LogicalDecodingContext *ctx);
+
+typedef void (*logicalrep_modify_slot_hook_type)(Relation rel, EState *estate, TupleTableSlot *slot);
+extern PGDLLIMPORT logicalrep_modify_slot_hook_type logicalrep_modify_slot_hook;
 
 #endif


### PR DESCRIPTION
During logical replication, subscriber instance should generate ROWVERSION/TIMESTAMP column values depending upon its own transaction IDs (epoch + xmin) instead of the values sent by the publisher instance.

This commit implements the following:

Added logic to skip replicating ROWVERSION/TIMESTAMP columns. This way the subscriber fills ROWVERSION/TIMESTAMP column with the new column default value for insert statements. Introduced a hook (is_tsql_rowversion_or_timestamp_datatype_hook) to determine if column attribute is of type ROWVERSION/TIMESTAMP. Introduced another hook (logicalrep_modify_slot_hook) to handle update statements; the hook is used to update the ROWVERSION/TIMESTAMP column with the new default value. Task: BABEL-2930
Author: Rishabh Tanwar ritanwar@amazon.com
Signed-off-by: Kushaal Shroff kushaal@amazon.com
(cherry picked from commit 8c94716f955a239a4c2d3779fb6c1df5464f84ee)