### PR TITLE
BABEL: MVU fails while recreating certain CASTS

### DIFF
--- a/src/bin/pg_dump/Makefile
+++ b/src/bin/pg_dump/Makefile
@@ -36,8 +36,8 @@ OBJS = \
 
 all: pg_dump pg_restore pg_dumpall
 
-pg_dump: pg_dump.o common.o pg_dump_sort.o $(OBJS) | submake-libpq submake-libpgport submake-libpgfeutils
-	$(CC) $(CFLAGS) pg_dump.o common.o pg_dump_sort.o $(OBJS) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
+pg_dump: pg_dump.o common.o pg_dump_sort.o dump_babel_utils.o $(OBJS) | submake-libpq submake-libpgport submake-libpgfeutils
+	$(CC) $(CFLAGS) pg_dump.o common.o pg_dump_sort.o dump_babel_utils.o $(OBJS) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
 
 pg_restore: pg_restore.o $(OBJS) | submake-libpq submake-libpgport submake-libpgfeutils
 	$(CC) $(CFLAGS) pg_restore.o $(OBJS) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
@@ -63,5 +63,5 @@ uninstall:
 	rm -f $(addprefix '$(DESTDIR)$(bindir)'/, pg_dump$(X) pg_restore$(X) pg_dumpall$(X))
 
 clean distclean maintainer-clean:
-	rm -f pg_dump$(X) pg_restore$(X) pg_dumpall$(X) $(OBJS) pg_dump.o common.o pg_dump_sort.o pg_restore.o pg_dumpall.o
+	rm -f pg_dump$(X) pg_restore$(X) pg_dumpall$(X) $(OBJS) pg_dump.o common.o pg_dump_sort.o pg_restore.o pg_dumpall.o dump_babel_utils.o
 	rm -rf tmp_check

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1,0 +1,48 @@
+/*-------------------------------------------------------------------------
+ *
+ * Utility routines for babelfish objects
+ *
+ * Portions Copyright (c) 1996-2021, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/bin/pg_dump/dump_babel_utils.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres_fe.h"
+
+#include "dump_babel_utils.h"
+#include "pg_dump.h"
+
+/*
+ * bbf_selectDumpableCast: Mark a cast as to be dumped or not
+ */
+void
+bbf_selectDumpableCast(CastInfo *cast)
+{
+	TypeInfo      *sTypeInfo;
+	TypeInfo      *tTypeInfo;
+	ExtensionInfo *ext = findOwningExtension(cast->dobj.catId);
+
+	/* Skip if cast is not a member of babelfish extension */
+	if (ext == NULL || strcmp(ext->dobj.name, "babelfishpg_common") != 0)
+		return;
+
+	sTypeInfo = findTypeByOid(cast->castsource);
+	tTypeInfo = findTypeByOid(cast->casttarget);
+
+	/*
+	 * Do not dump following unused CASTS:
+	 * pg_catalog.bool -> sys.bpchar
+	 * pg_catalog.bool -> sys.varchar
+	 */
+	if (sTypeInfo && tTypeInfo &&
+			sTypeInfo->dobj.namespace &&
+			tTypeInfo->dobj.namespace &&
+			strcmp(sTypeInfo->dobj.namespace->dobj.name, "pg_catalog") == 0 &&
+			strcmp(tTypeInfo->dobj.namespace->dobj.name, "sys") == 0 &&
+			strcmp(sTypeInfo->dobj.name, "bool") == 0 &&
+			(strcmp(tTypeInfo->dobj.name, "bpchar") == 0 ||
+			 strcmp(tTypeInfo->dobj.name, "varchar") == 0))
+		cast->dobj.dump = DUMP_COMPONENT_NONE;
+}

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -1,0 +1,19 @@
+/*-------------------------------------------------------------------------
+ *
+ * Utility routines for babelfish objects
+ *
+ * Portions Copyright (c) 1996-2021, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/bin/pg_dump/dump_babel_utils.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef DUMP_BABEL_UTILS_H
+#define DUMP_BABEL_UTILS_H
+
+#include "pg_dump.h"
+
+extern void bbf_selectDumpableCast(CastInfo *cast);
+
+#endif

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -55,6 +55,7 @@
 #include "catalog/pg_trigger_d.h"
 #include "catalog/pg_type_d.h"
 #include "common/connect.h"
+#include "dump_babel_utils.h"
 #include "dumputils.h"
 #include "fe_utils/option_utils.h"
 #include "fe_utils/string_utils.h"
@@ -7925,6 +7926,7 @@ getCasts(Archive *fout, int *numCasts)
 
 		/* Decide whether we want to dump it */
 		selectDumpableCast(&(castinfo[i]), fout);
+		bbf_selectDumpableCast(&(castinfo[i]));
 	}
 
 	PQclear(res);


### PR DESCRIPTION
pg_restore throws error "return data type of cast function must match or be binary-coercible to target data type" while restoring some CASTS.

The reason for the error is that PG does not record dependencies between CASTS so we get an error if we try to create a CAST before creating it's dependencies.

Fixed this by not dumping those problematic CASTS, which is okay since those CASTS are removed in bbf version 2.0.0 and later versions. Created a separate file to put all the logic to dump babelfish extension objects.

Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>
(cherry picked from commit 9dcd7203b63834e0d71aa51c8dca37a2d2e5de7d)