### PR TITLE
BABEL: Fix MVU failure regarding runtime_error function (#11)

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -22,6 +22,7 @@
 
 
 extern void bbf_selectDumpableCast(CastInfo *cast);
+extern void fixTsqlDefaultExpr(Archive *fout, AttrDefInfo *attrDefInfo);
 extern bool isBabelfishDatabase(Archive *fout);
 extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
 extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -8395,6 +8395,9 @@ getTableAttrs(Archive *fout, TableInfo *tblinfo, int numTables)
 			attrdefs[j].adnum = adnum;
 			attrdefs[j].adef_expr = pg_strdup(adsrc);
 
+			/* Babelfish-specific logic for default expr */
+			fixTsqlDefaultExpr(fout, &attrdefs[j]);
+
 			attrdefs[j].dobj.name = pg_strdup(tbinfo->dobj.name);
 			attrdefs[j].dobj.namespace = tbinfo->dobj.namespace;
 


### PR DESCRIPTION
T-SQL allows an empty/space-only string as a default constraint of NUMERIC column in CREATE TABLE statement. However, it will eventually throw an error when actual INSERT happens for the default value.

To support this behavior, we use a function
sys.babelfish_runtime_error(), which raises an error in execution time.

However, pg_dump evaluates the runtime error function and replaces it with an error string that causes MVU failure during restore. This commit replaces the error string by sys.babelfish_runtime_error() again.

Task: BABEL-3234
Signed-off-by: Jungkook Lee <jungkook@amazon.com>
(cherry picked from commit fc433a848a509b145e315617082a70bee9b64523)