### PR TITLE
BABEL: Support pg_upgrade for TSQL triggers (#12)

### DIFF
--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -41,6 +41,7 @@
 PGDLLIMPORT needs_fmgr_hook_type needs_fmgr_hook = NULL;
 PGDLLIMPORT fmgr_hook_type fmgr_hook = NULL;
 PGDLLIMPORT non_tsql_proc_entry_hook_type non_tsql_proc_entry_hook = NULL;
+PGDLLIMPORT get_func_language_oids_hook_type get_func_language_oids_hook = NULL;
 
 /*
  * Hashtable for fast lookup of external C functions
@@ -213,7 +214,7 @@ fmgr_info_cxt_security(Oid functionId, FmgrInfo *finfo, MemoryContext mcxt,
 		  * to have sql_dialect be either postgres or tsql according to
 		  * their language.
 		  */
-		 (*find_rendezvous_variable("PLtsql_config") != NULL) ||
+		 (get_func_language_oids_hook != NULL) ||
 		 FmgrHookIsNeeded(functionId)))
 	{
 		finfo->fn_addr = fmgr_security_definer;
@@ -740,40 +741,13 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 	else
 		fcache = fcinfo->flinfo->fn_extra;
 
-	/*
-	 * If babelfishpg_tsql extension is installed, set proconfig of sql_dialect
-	 */
+	if (get_func_language_oids_hook)
+		get_func_language_oids_hook(&pltsql_lang_oid, &pltsql_validator_oid);
+	else
 	{
-		/*
-		 * FIXME: the following typedef (PLtsql_config) describes a 
-		 * structure shared with PLtsql.  Since the type is shared, 
-		 * we should find a header file that is properly shared and
-		 * move this typedef
-		 *
-		 * This typedef *must* be kept in-synch with the PLtsql_config
-		 * type declaration found in contrib/babelfishpg_tsql/src/pgtsql.h
-		 */
-		typedef struct PLtsql_config
-		{
-			char	*version;         /* Extension version info */
-			Oid		 handler_oid;     /* Oid of language handler function */
-			Oid		 validator_oid;   /* Oid of language validator function */
-		} PLtsql_config;
-		
-		PLtsql_config **config = (PLtsql_config **) find_rendezvous_variable("PLtsql_config");
-
-		if (*config)
-		{
-			pltsql_lang_oid = (*config)->handler_oid;
-			pltsql_validator_oid = (*config)->validator_oid;
-		}
-		else
-		{
-			pltsql_lang_oid = InvalidOid;
-			pltsql_validator_oid = InvalidOid;
-		}
+		pltsql_lang_oid = InvalidOid;
+		pltsql_validator_oid = InvalidOid;
 	}
-	
 
 	// get_language_procs("pltsql", &pltsql_lang_oid, &pltsql_validator_oid);
 	set_sql_dialect = pltsql_lang_oid != InvalidOid;

--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -776,9 +776,12 @@ typedef void (*fmgr_hook_type) (FmgrHookEventType event,
 
 typedef void (*non_tsql_proc_entry_hook_type) (int, int);
 
+typedef void (*get_func_language_oids_hook_type)(Oid *, Oid *);
+
 extern PGDLLIMPORT needs_fmgr_hook_type needs_fmgr_hook;
 extern PGDLLIMPORT fmgr_hook_type fmgr_hook;
 extern PGDLLIMPORT non_tsql_proc_entry_hook_type non_tsql_proc_entry_hook;
+extern PGDLLIMPORT get_func_language_oids_hook_type get_func_language_oids_hook;
 
 #define FmgrHookIsNeeded(fn_oid)							\
 	(!needs_fmgr_hook ? false : (*needs_fmgr_hook)(fn_oid))


### PR DESCRIPTION
TSQL triggers supports more features and feature combinations when compared to PG triggers. This is implemented using TSQL dialect check when running triggers DDLs. During restore, TSQL triggers are created with PG dialect and they error out due to not supported features/combinations in PG.

As a fix, create trigger will rely on trigger function language (TSQL vs PG) instead of dialect to support TSQL features. This will work for trigger creation in all cases including restore.

Task : BABEL-3249

Signed-off-by: Surendra Vishnoi <vishnosu@amazon.com>
(cherry picked from commit 4efe25407d0c731c24dc4a0f1155b480fae1989d)