### PR TITLE
BABEL: fix the bug instead of trigger behaves wrongly in recursively call (#31)

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -5290,7 +5290,7 @@ isTsqlInsteadofTriggerExecution(EState *estate, ResultRelInfo *relinfo, TriggerE
 	{
 		Trigger *trigger = &trigdesc->triggers[i];
 		if (TriggerEnabled(estate, relinfo, trigger, event, NULL, NULL, NULL)){
-			return true;
+			return !TsqlRecuresiveCheck(relinfo);
 		}
 	}
 	return false;
@@ -7193,6 +7193,12 @@ void BeginCompositeTriggers(MemoryContext curCxt)
 {
 	compositeTriggers.triggerLevel++;
 	compositeTriggers.curCxt = curCxt;
+}
+
+bool TsqlRecuresiveCheck(ResultRelInfo *resultRelInfo){
+	if (TriggerRecuresiveCheck_hook)
+		return TriggerRecuresiveCheck_hook(resultRelInfo);
+	else return false;
 }
 
 /*

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -74,6 +74,7 @@ ExecutorRun_hook_type ExecutorRun_hook = NULL;
 ExecutorFinish_hook_type ExecutorFinish_hook = NULL;
 ExecutorEnd_hook_type ExecutorEnd_hook = NULL;
 
+TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook = NULL;
 /* Hook for plugin to get control in ExecCheckRTPerms() */
 ExecutorCheckPerms_hook_type ExecutorCheckPerms_hook = NULL;
 

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -780,9 +780,11 @@ ExecInsert(ModifyTableContext *context,
 			return NULL;		/* "do nothing" */
 	}
 	else if (sql_dialect == SQL_DIALECT_TSQL && resultRelInfo->ri_TrigDesc &&
-		resultRelInfo->ri_TrigDesc->trig_insert_instead_statement){
+		resultRelInfo->ri_TrigDesc->trig_insert_instead_statement && !TsqlRecuresiveCheck(resultRelInfo)){
 		ExecIRInsertTriggersTSQL(estate, resultRelInfo, slot, mtstate->mt_transition_capture);
 		// if it's a statement level IOT trigger, only get the transition table
+		if (canSetTag)
+			(estate->es_processed)++;
 		return NULL;
 	}
 	else if (resultRelInfo->ri_FdwRoutine)
@@ -1380,6 +1382,8 @@ ExecDelete(ModifyTableContext *context,
 		isTsqlInsteadofTriggerExecution(estate, resultRelInfo, TRIGGER_EVENT_DELETE))
 	{
 		ExecIRDeleteTriggersTSQL(estate, resultRelInfo, tupleid, oldtuple, context->mtstate->mt_transition_capture);
+		if (canSetTag)
+			(estate->es_processed)++;
 		return NULL;
 	}
 
@@ -2218,6 +2222,8 @@ ExecUpdate(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
 		isTsqlInsteadofTriggerExecution(estate, resultRelInfo, TRIGGER_EVENT_INSTEAD))
 	{
 		ExecIRUpdateTriggersTSQL(estate, resultRelInfo, tupleid, oldtuple, slot, recheckIndexes, context->mtstate->mt_transition_capture);
+		if (canSetTag)
+			(estate->es_processed)++;
 		return NULL;
 	}
 

--- a/src/include/commands/trigger.h
+++ b/src/include/commands/trigger.h
@@ -311,4 +311,6 @@ extern int	RI_FKey_trigger_type(Oid tgfoid);
 extern void BeginCompositeTriggers(MemoryContext curCxt);
 extern void EndCompositeTriggers(bool error);
 
+extern bool TsqlRecuresiveCheck(ResultRelInfo *resultRelInfo);
+
 #endif							/* TRIGGER_H */

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -84,6 +84,8 @@ extern PGDLLIMPORT ExecutorEnd_hook_type ExecutorEnd_hook;
 typedef bool (*ExecutorCheckPerms_hook_type) (List *, bool);
 extern PGDLLIMPORT ExecutorCheckPerms_hook_type ExecutorCheckPerms_hook;
 
+typedef bool (*TriggerRecuresiveCheck_hook_type) (ResultRelInfo *resultRelInfo);
+extern PGDLLIMPORT TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook;
 
 /*
  * prototypes from functions in execAmi.c

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -271,6 +271,8 @@ extern PGDLLIMPORT double log_xact_sample_rate;
 extern PGDLLIMPORT char *backtrace_functions;
 extern PGDLLIMPORT char *backtrace_symbol_list;
 
+extern bool pltsql_recursive_triggers;
+
 extern PGDLLIMPORT int temp_file_limit;
 
 extern PGDLLIMPORT int num_temp_buffers;

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -673,6 +673,7 @@ ExecStatus
 ExecStatusType
 ExecuteStmt
 ExecutorCheckPerms_hook_type
+TriggerRecuresiveCheck_hook_type
 ExecutorEnd_hook_type
 ExecutorFinish_hook_type
 ExecutorRun_hook_type


### PR DESCRIPTION
recursively call the instead of trigger may lose the last DML to the triggered table

in previous impl, recursively trigger a instead of trigger will not do any changes into the triggered table, as for the last triggered DML, it shouldn't do the instead of procedure, what it should do is to do DML in the table, since the last DML in a recursive trig chain should not trig it's trigger

Task: BABEL-3115 & BABEL-3116 & BABEL-3118
Signed-off-by: Zhibai Song <szh@amazon.com>
Co-authored-by: Zhibai Song <szh@amazon.com>
(cherry picked from commit 0a65a6039e60fbe1017689f9b91ffdc28875719d)