### PR TITLE
BABEL: Adding support for SELECT FOR JSON (#57)

### DIFF
--- a/src/backend/utils/adt/json.c
+++ b/src/backend/utils/adt/json.c
@@ -1774,3 +1774,20 @@ json_typeof(PG_FUNCTION_ARGS)
 
 	PG_RETURN_TEXT_P(cstring_to_text(type));
 }
+
+
+/*
+ * SQL function tsql_json_build_object()
+ * 
+ * Transform the input key,val into json key:val pair
+ */
+void
+tsql_json_build_object(StringInfo result,Datum colname, Datum colval, Oid collation, bool is_null)
+{	
+	add_json(colname, false, result, CSTRINGOID, true);
+
+	appendStringInfoString(result, ":");
+	
+	add_json(colval, is_null, result, collation, false);
+}
+

--- a/src/include/parser/parser.h
+++ b/src/include/parser/parser.h
@@ -83,6 +83,19 @@ typedef enum
 	DATEFIRST_SUNDAY
 } DATEFIRST;
 
+/* Enum declaration to support FOR JSON clause */
+typedef enum
+{
+	TSQL_FORJSON_AUTO,
+	TSQL_FORJSON_PATH,
+} TSQLFORJSONMode;
+
+typedef enum
+{
+	TSQL_JSON_DIRECTIVE_INCLUDE_NULL_VALUES,
+	TSQL_JSON_DIRECTIVE_WITHOUT_ARRAY_WRAPPER
+} TSQLJSONDirective;
+
 /* GUC variables in scan.l (every one of these is a bad idea :-() */
 extern PGDLLIMPORT int backslash_quote;
 extern PGDLLIMPORT bool escape_string_warning;

--- a/src/include/utils/json.h
+++ b/src/include/utils/json.h
@@ -46,5 +46,6 @@ extern Datum json_build_object_worker(int nargs, Datum *args, bool *nulls,
 extern Datum json_build_array_worker(int nargs, Datum *args, bool *nulls,
 									 Oid *types, bool absent_on_null);
 extern bool json_validate(text *json, bool check_unique_keys, bool throw_error);
+extern void tsql_json_build_object(StringInfo result,Datum colname, Datum colval, Oid collation, bool is_null);
 
 #endif							/* JSON_H */


### PR DESCRIPTION
- Enum declaration of FOR JSON modes and directives
- function support for converting input key,val into json key, value pair

Extension PR: babelfish-for-postgresql/babelfish_extensions#769

TASK: BABEL-3669
Signed-off-by: Anuj Sarda sardanuj@amazon.com
(cherry picked from commit 66383e80ee865a67cb0d4b15bc118a86410418f1)