### PR TITLE
 Fix ambiguous function calls during restore

### DIFF
--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -1269,7 +1269,8 @@ func_select_candidate(int nargs,
 	 * let's try to choose the best candidate by T-SQL precedence rule with setting resolved_unknowns.
 	 */
 	if (resolved_unknowns &&
-		sql_dialect == SQL_DIALECT_TSQL &&
+		(sql_dialect == SQL_DIALECT_TSQL ||
+		(dump_restore && strcmp(dump_restore, "on") == 0)) && /* execute hook if dialect is T-SQL or while restoring babelfish database */
 		func_select_candidate_hook != NULL)
 	{
 		last_candidate = func_select_candidate_hook(nargs, input_typeids, candidates, true);


### PR DESCRIPTION
### Description
During restore certain function calls get failed since `func_select_candidate_hook`
is allowed only in `TSQL` dialect.
To fix this, added a check for dump_restore GUC along with `sql_dialect` check.

Task: BABEL-3826
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Example:
Original table:
```
> CREATE TABLE BABEL_1475_vu_prepare_day (dt1 datetime2, dt2 datetimeoffset(6), day1 as DAY(dt1), day2 as DAY(dt2));

> INSERT INTO BABEL_1475_vu_prepare_day (dt1, dt2) values ('2007-01-01 13:10:10.1111111', '1912-10-25 12:24:32 +10:0');
 
```
Dumped SQL and error:
```
INSERT INTO "master_dbo"."babel_1475_vu_prepare_day" ("dt1", "dt2") VALUES ('2007-01-01 13:10:10.111111', '1912-10-25 12:24:32 +10:00');

psql:pg_upgrade_dump1.sql:38396: ERROR:  function sys.datepart(unknown, sys.datetime2) is not unique
LINE 2: SELECT sys.datepart('day', date);
               ^
HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
QUERY:  
SELECT sys.datepart('day', date);CONTEXT:  SQL function "day" during inlining
```