### PR TITLE
Correctly mark Babelfish configuration tables

### DIFF
--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -2537,7 +2537,7 @@ pg_extension_config_dump(PG_FUNCTION_ARGS)
  * This is not currently exposed as a function, but it could be;
  * for now, we just invoke it from ALTER EXTENSION DROP.
  */
-static void
+void
 extension_config_remove(Oid extensionoid, Oid tableoid)
 {
 	Relation	extRel;

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -1269,7 +1269,8 @@ func_select_candidate(int nargs,
 	 * let's try to choose the best candidate by T-SQL precedence rule with setting resolved_unknowns.
 	 */
 	if (resolved_unknowns &&
-		sql_dialect == SQL_DIALECT_TSQL &&
+		(sql_dialect == SQL_DIALECT_TSQL ||
+		(dump_restore && strcmp(dump_restore, "on") == 0)) && /* execute hook if dialect is T-SQL or while restoring babelfish database */
 		func_select_candidate_hook != NULL)
 	{
 		last_candidate = func_select_candidate_hook(nargs, input_typeids, candidates, true);

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -523,20 +523,21 @@ updateExtConfigArray(Archive *fout, char ***extconfigarray, int nconfigitems)
 						 "ORDER BY relname;");
 
 	res = ExecuteSqlQuery(fout, query->data, PGRES_TUPLES_OK);
-	Assert(PQntuples(res) == 2);
-	bbf_user_ext_tbl_oid = pg_strdup(PQgetvalue(res, 0, 0));
-	bbf_config_tbl_oid = atooid(PQgetvalue(res, 1, 0));
+
+	if(PQntuples(res) == 2)
+	{
+		bbf_user_ext_tbl_oid = PQgetvalue(res, 0, 0);
+		bbf_config_tbl_oid = atooid(PQgetvalue(res, 1, 0));
+
+		for (i = 0; i < nconfigitems; i++)
+		{
+			Oid configtbloid = atooid((*extconfigarray)[i]);
+
+			if (configtbloid == bbf_config_tbl_oid)
+				(*extconfigarray)[i] = pg_strdup(bbf_user_ext_tbl_oid);
+		}
+	}
 
 	PQclear(res);
 	resetPQExpBuffer(query);
-
-	for (i = 0; i < nconfigitems; i++)
-	{
-		Oid			configtbloid;
-
-		configtbloid = atooid((*extconfigarray)[i]);
-
-		if (configtbloid == bbf_config_tbl_oid)
-			(*extconfigarray)[i] = bbf_user_ext_tbl_oid;
-	}
 }

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -580,3 +580,59 @@ babelfish_handle_view_def(Archive *fout, char *view_def)
 
 	return babelfishRemoveSubstr(view_def, defaultCollation);
 }
+
+/*
+ * updateExtConfigArray:
+ * In some old Babelfish versions, we have incorrectly marked some extension
+ * configuration tables as follows:
+ * 1. Table sys.babelfish_authid_user_ext has not been marked as config table.
+ * 2. Table sys.babelfish_configurations has been marked as configuration table
+ *    but it is not supposed to.
+ * So the function takes babelfishpg_tsql extension's configuration array(extconfigarray)
+ * and replaces OID of sys.babelfish_configurations table with the OID of
+ * sys.babelfish_authid_user_ext table. This will ensure that we will dump the data
+ * of table sys.babelfish_authid_user_ext instead of sys.babelfish_configurations.
+ */
+void
+updateExtConfigArray(Archive *fout, char ***extconfigarray, int nconfigitems)
+{
+	char		*bbf_user_ext_tbl_oid;
+	Oid			bbf_config_tbl_oid;
+	PQExpBuffer query;
+	PGresult	*res;
+	int			i;
+	if (!isBabelfishDatabase(fout))
+		return;
+
+	query = createPQExpBuffer();
+
+	/*
+	 * Get OIDs of sys.babelfish_authid_user_ext and sys.babelfish_configurations tables.
+	 * Later we will replace sys.babelfish_configurations table's OID with the OID of
+	 * sys.babelfish_authid_user_ext table in extconfigarray.
+	 */
+	appendPQExpBufferStr(query,
+						 "SELECT oid "
+						 "FROM pg_catalog.pg_class "
+						 "WHERE relname IN ('babelfish_authid_user_ext', 'babelfish_configurations') "
+						 "AND relnamespace = 'sys'::regnamespace "
+						 "ORDER BY relname;");
+
+	res = ExecuteSqlQuery(fout, query->data, PGRES_TUPLES_OK);
+	Assert(PQntuples(res) == 2);
+	bbf_user_ext_tbl_oid = pg_strdup(PQgetvalue(res, 0, 0));
+	bbf_config_tbl_oid = atooid(PQgetvalue(res, 1, 0));
+
+	PQclear(res);
+	resetPQExpBuffer(query);
+
+	for (i = 0; i < nconfigitems; i++)
+	{
+		Oid			configtbloid;
+
+		configtbloid = atooid((*extconfigarray)[i]);
+
+		if (configtbloid == bbf_config_tbl_oid)
+			(*extconfigarray)[i] = bbf_user_ext_tbl_oid;
+	}
+}

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -34,5 +34,6 @@ extern void fixAttoptionsBbfOriginalName(Archive *fout, Oid relOid, const TableI
 extern void setOrResetPltsqlFuncRestoreGUCs(Archive *fout, PQExpBuffer q, const FuncInfo *finfo, char prokind, bool proretset, bool is_set);
 extern void dumpBabelfishSpecificConfig(Archive *AH, const char *dbname, PQExpBuffer outbuf);
 extern char *babelfish_handle_view_def(Archive *fout, char *view_def);
+extern void updateExtConfigArray(Archive *fout, char ***extconfigarray, int nconfigitems);
 
 #endif

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -17633,6 +17633,9 @@ processExtensionTables(Archive *fout, ExtensionInfo extinfo[],
 			if (nconfigitems != nconditionitems)
 				pg_fatal("mismatched number of configurations and conditions for extension");
 
+			if (strcmp(curext->dobj.name, "babelfishpg_tsql") == 0)
+				updateExtConfigArray(fout, &extconfigarray, nconfigitems);
+
 			for (j = 0; j < nconfigitems; j++)
 			{
 				TableInfo  *configtbl;

--- a/src/include/commands/extension.h
+++ b/src/include/commands/extension.h
@@ -51,5 +51,6 @@ extern bool extension_file_exists(const char *extensionName);
 
 extern ObjectAddress AlterExtensionNamespace(const char *extensionName, const char *newschema,
 											 Oid *oldschema);
+extern void extension_config_remove(Oid extensionoid, Oid tableoid);
 
 #endif							/* EXTENSION_H */


### PR DESCRIPTION
### Description
In all previous Babelfish versions, we have incorrectly marked some extension
configuration tables as follows:
 * 1. Table sys.babelfish_authid_user_ext has not been marked as config table.
 * 2. Table sys.babelfish_configurations has been marked as configuration table
but it is not supposed to.

Due to the above fact, we observe following issues on a restored server:
1. sys.babelfish_authid_user_ext catalog table turns out to be empty due to
which we see some obvious catalog inconsistencies.
2. sys.babelfish_configurations shows duplicate entries as one entry come
from extension's installation file and other comes from dump file.

We fix this issue as follows:
1. For old Babelfish versions, modified pg_dump to forcefully dump
sys.babelfish_authid_user_ext table's data but skip dumping the data of
sys.babelfish_configurations table. Introduced function `updateExtConfigArray`
for this purpose.
2. For new Babelfish versions, marked sys.babelfish_authid_user_ext table as
configuration table using `pg_extension_config_dump` function and unmark
sys.babelfish_configurations table using `pg_extension_config_remove`.

Note that postgres has not exposed `pg_extension_config_remove` as SQL
function so we have implemented a SQL wrapper function in the extension
for it.

Task: BABEL-3825
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>