### PR TITLE
Dump missing column of babelfish_authid_login_ext catalog

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -33,5 +33,6 @@ extern void fixAttoptionsBbfOriginalName(Archive *fout, Oid relOid, const TableI
 extern void setOrResetPltsqlFuncRestoreGUCs(Archive *fout, PQExpBuffer q, const FuncInfo *finfo, char prokind, bool proretset, bool is_set);
 extern void dumpBabelfishSpecificConfig(Archive *AH, const char *dbname, PQExpBuffer outbuf);
 extern void updateExtConfigArray(Archive *fout, char ***extconfigarray, int nconfigitems);
+extern void fixCopyCommand(Archive *fout, PQExpBuffer copyBuf, TableInfo *tbinfo, bool isFrom);
 
 #endif


### PR DESCRIPTION
### Description
[Commit](https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/82902f42416c72205d4fcbba4c6f5c6c7c0d606e) added a new column `orig_loginname` in babelfish_authid_login_ext table with a `NOT NULL` constraint. To satisfy the `NOT NULL`
constraint for existing rows, it has added a special handling in upgrade script for this new column
so that value of this new column get set equal to `rolname` column for all the existing rows.

This commit adds the same handling in pg_dump for the new column since upgrade scripts
do not get executed while restoring a dump file.
We will always dump this `orig_loginname` column if not already present since the current version
(PG 15.3, Babelfish 3.2.0) is the first version we are going to support restore.

Task: BABEL-3983
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>