### PR TITLE
Do not dump ROWVERSION/TIMESTAMP column values

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -2149,9 +2149,14 @@ dumpTableData_insert(Archive *fout, const void *dcontext)
 			continue;
 		if (tbinfo->attgenerated[i] && dopt->column_inserts)
 			continue;
+
 		/* rowversion/timestamp columns need to be skipped as instead of dumping they should be re-generated */
-		if (pg_strcasecmp(tbinfo->atttypnames[i], "\"sys\".\"rowversion\"") == 0 || pg_strcasecmp(tbinfo->atttypnames[i], "\"sys\".\"timestamp\"") == 0)
-			continue;
+		if (pg_strcasecmp(tbinfo->atttypnames[i], 
+			quote_all_identifiers ? "\"sys\".\"rowversion\"" : "sys.rowversion") == 0 || 
+			pg_strcasecmp(tbinfo->atttypnames[i], 
+			quote_all_identifiers ? "\"sys\".\"timestamp\"": "sys.timestamp") == 0)
+		continue;
+
 		if (nfields > 0)
 			appendPQExpBufferStr(q, ", ");
 		if (tbinfo->attgenerated[i])
@@ -18220,10 +18225,12 @@ fmtCopyColumnList(const TableInfo *ti, PQExpBuffer buffer)
 		if (attgenerated[i])
 			continue;
 
-		/* rowversion/timestamp columns need to be skipped as instead of dumping they should be re-generated */
-		if (pg_strcasecmp(atttypnames[i], "\"sys\".\"rowversion\"") == 0 || pg_strcasecmp(atttypnames[i], "\"sys\".\"timestamp\"") == 0)
-		continue;
+		pg_log_info("atttypenames: %s, fmtId: %s", atttypnames[i], fmtId("\"sys\".\"rowversion\""));
 
+		/* rowversion/timestamp columns need to be skipped as instead of dumping they should be re-generated */
+		if (pg_strcasecmp(atttypnames[i], fmtId("\"sys\".\"rowversion\"")) == 0 || pg_strcasecmp(atttypnames[i], fmtId("\"sys\".\"timestamp\"")) == 0)
+		continue;
+		
 		if (needComma)
 			appendPQExpBufferStr(buffer, ", ");
 		appendPQExpBufferStr(buffer, fmtId(attnames[i]));

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -18202,6 +18202,7 @@ fmtCopyColumnList(const TableInfo *ti, PQExpBuffer buffer)
 {
 	int			numatts = ti->numatts;
 	char	  **attnames = ti->attnames;
+	char	  **atttypnames = ti->atttypnames;
 	bool	   *attisdropped = ti->attisdropped;
 	char	   *attgenerated = ti->attgenerated;
 	bool		needComma;
@@ -18214,6 +18215,8 @@ fmtCopyColumnList(const TableInfo *ti, PQExpBuffer buffer)
 		if (attisdropped[i])
 			continue;
 		if (attgenerated[i])
+			continue;
+		if (atttypnames[i] == "rowversion" || atttypnames[i] == "timestamp")
 			continue;
 		if (needComma)
 			appendPQExpBufferStr(buffer, ", ");

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -2149,6 +2149,9 @@ dumpTableData_insert(Archive *fout, const void *dcontext)
 			continue;
 		if (tbinfo->attgenerated[i] && dopt->column_inserts)
 			continue;
+		/* rowversion/timestamp columns need to be skipped as instead of dumping they should be re-generated */
+		if (pg_strcasecmp(tbinfo->atttypnames[i], "\"sys\".\"rowversion\"") == 0 || pg_strcasecmp(tbinfo->atttypnames[i], "\"sys\".\"timestamp\"") == 0)
+			continue;
 		if (nfields > 0)
 			appendPQExpBufferStr(q, ", ");
 		if (tbinfo->attgenerated[i])
@@ -18216,8 +18219,11 @@ fmtCopyColumnList(const TableInfo *ti, PQExpBuffer buffer)
 			continue;
 		if (attgenerated[i])
 			continue;
-		if (strcmp(atttypnames[i], "rowversion") == 0 || strcmp(atttypnames[i], "timestamp") == 0)
-			continue;
+
+		/* rowversion/timestamp columns need to be skipped as instead of dumping they should be re-generated */
+		if (pg_strcasecmp(atttypnames[i], "\"sys\".\"rowversion\"") == 0 || pg_strcasecmp(atttypnames[i], "\"sys\".\"timestamp\"") == 0)
+		continue;
+
 		if (needComma)
 			appendPQExpBufferStr(buffer, ", ");
 		appendPQExpBufferStr(buffer, fmtId(attnames[i]));

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -18225,12 +18225,13 @@ fmtCopyColumnList(const TableInfo *ti, PQExpBuffer buffer)
 		if (attgenerated[i])
 			continue;
 
-		pg_log_info("atttypenames: %s, fmtId: %s", atttypnames[i], fmtId("\"sys\".\"rowversion\""));
-
 		/* rowversion/timestamp columns need to be skipped as instead of dumping they should be re-generated */
-		if (pg_strcasecmp(atttypnames[i], fmtId("\"sys\".\"rowversion\"")) == 0 || pg_strcasecmp(atttypnames[i], fmtId("\"sys\".\"timestamp\"")) == 0)
+		if (pg_strcasecmp(atttypnames[i], 
+			quote_all_identifiers ? "\"sys\".\"rowversion\"" : "sys.rowversion") == 0 || 
+			pg_strcasecmp(atttypnames[i], 
+			quote_all_identifiers ? "\"sys\".\"timestamp\"": "sys.timestamp") == 0)
 		continue;
-		
+
 		if (needComma)
 			appendPQExpBufferStr(buffer, ", ");
 		appendPQExpBufferStr(buffer, fmtId(attnames[i]));

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -18216,7 +18216,7 @@ fmtCopyColumnList(const TableInfo *ti, PQExpBuffer buffer)
 			continue;
 		if (attgenerated[i])
 			continue;
-		if (atttypnames[i] == "rowversion" || atttypnames[i] == "timestamp")
+		if (strcmp(atttypnames[i], "rowversion") == 0 || strcmp(atttypnames[i], "timestamp") == 0)
 			continue;
 		if (needComma)
 			appendPQExpBufferStr(buffer, ", ");


### PR DESCRIPTION
### Description 

ROWVERSION/TIMESTAMP column values should not get dumped by pg_dump, instead these columns should be recomputed in the target cluster.

Task: BABEL-3504, BABEL-3452
Signed-off-by: Aditya Verma <adiityav@amazon.com>

### Testing 
##### Use case based:
##### Negative tests case scenarios
##### Arbitrary inputs 
##### Minor version upgrade tests
##### Major version upgrade tests
#### Tests for BABEL-3504
##### Use case based:
##### Negative tests case scenarios:
##### Arbitrary inputs 
##### Minor version upgrade tests

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).