### PR TITLE
Support database-level dump/restore

### DIFF
--- a/src/backend/commands/copyfromparse.c
+++ b/src/backend/commands/copyfromparse.c
@@ -147,6 +147,8 @@ if (1) \
 /* NOTE: there's a copy of this in copyto.c */
 static const char BinarySignature[11] = "PGCOPY\n\377\r\n\0";
 
+/* hooks */
+fill_missing_values_in_copyfrom_hook_type fill_missing_values_in_copyfrom_hook = NULL;
 
 /* non-export function prototypes */
 static bool CopyReadLine(CopyFromState cstate);
@@ -1022,6 +1024,9 @@ NextCopyFrom(CopyFromState cstate, ExprContext *econtext,
 		values[defmap[i]] = ExecEvalExpr(defexprs[i], econtext,
 										 &nulls[defmap[i]]);
 	}
+
+	if (fill_missing_values_in_copyfrom_hook)
+		fill_missing_values_in_copyfrom_hook(cstate->rel, values, nulls);
 
 	return true;
 }

--- a/src/bin/pg_dump/Makefile
+++ b/src/bin/pg_dump/Makefile
@@ -43,8 +43,8 @@ pg_dump: pg_dump.o common.o pg_dump_sort.o dump_babel_utils.o $(OBJS) | submake-
 pg_restore: pg_restore.o $(OBJS) | submake-libpq submake-libpgport submake-libpgfeutils
 	$(CC) $(CFLAGS) pg_restore.o $(OBJS) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
 
-pg_dumpall: pg_dumpall.o dumputils.o $(WIN32RES) | submake-libpq submake-libpgport submake-libpgfeutils
-	$(CC) $(CFLAGS) pg_dumpall.o dumputils.o $(WIN32RES) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
+pg_dumpall: pg_dumpall.o dumputils.o dumpall_babel_utils.o $(WIN32RES) | submake-libpq submake-libpgport submake-libpgfeutils
+	$(CC) $(CFLAGS) pg_dumpall.o dumputils.o dumpall_babel_utils.o $(WIN32RES) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
 
 install: all installdirs
 	$(INSTALL_PROGRAM) pg_dump$(X) '$(DESTDIR)$(bindir)'/pg_dump$(X)

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -16,11 +16,26 @@
 #include "catalog/pg_type_d.h"
 #include "common/logging.h"
 #include "dump_babel_utils.h"
+#include "fe_utils/string_utils.h"
+#include "pg_backup_archiver.h"
 #include "pg_backup_db.h"
+#include "pg_backup_utils.h"
+#include "pg_backup.h"
 #include "pg_dump.h"
 #include "pqexpbuffer.h"
 
-char *
+/*
+ * Macro for producing quoted, schema-qualified name of a dumpable object.
+ */
+#define fmtQualifiedDumpable(obj) \
+	fmtQualifiedId((obj)->dobj.namespace->dobj.name, \
+				   (obj)->dobj.name)
+
+static const CatalogId nilCatalogId = {0, 0};
+
+static char *getMinOid(Archive *fout);
+
+static char *
 getMinOid(Archive *fout)
 {
 	PGresult *res;
@@ -92,6 +107,35 @@ isBabelfishDatabase(Archive *fout)
 }
 
 /*
+ * dumpBabelGUCs:
+ * Dumps Babelfish specific GUC settings if current
+ * database is a Babelfish database.
+ */
+void
+dumpBabelGUCs(Archive *fout)
+{
+	char		*oid;
+	PQExpBuffer qry;
+
+	if (!isBabelfishDatabase(fout))
+		return;
+
+	qry = createPQExpBuffer();
+	oid = getMinOid(fout);
+	appendPQExpBufferStr(qry, "SET babelfishpg_tsql.dump_restore = TRUE;\n");
+	appendPQExpBuffer(qry, "SET babelfishpg_tsql.dump_restore_min_oid = %s;\n", oid);
+	free(oid);
+
+	ArchiveEntry(fout, nilCatalogId, createDumpId(),
+				 ARCHIVE_OPTS(.tag = "BABELFISHGUCS",
+							  .description = "BABELFISHGUCS",
+							  .section = SECTION_PRE_DATA,
+							  .createStmt = qry->data));
+
+	destroyPQExpBuffer(qry);
+}
+
+/*
  * bbf_selectDumpableCast: Mark a cast as to be dumped or not
  */
 void
@@ -122,6 +166,32 @@ bbf_selectDumpableCast(CastInfo *cast)
 			(strcmp(tTypeInfo->dobj.name, "bpchar") == 0 ||
 			 strcmp(tTypeInfo->dobj.name, "varchar") == 0))
 		cast->dobj.dump = DUMP_COMPONENT_NONE;
+}
+
+/*
+ * bbf_selectDumpableTableData:
+ * Marks Babelfish catalog table data to be dumped if not in binary-upgrade mode.
+ * It is mostly used during Babelfish logical database dump as none of the extensions
+ * are marked to be dumped so catalog table data explicitly need to be marked as dumpable.
+ */
+void
+bbf_selectDumpableTableData(TableInfo *tbinfo, Archive *fout)
+{
+	if (!isBabelfishDatabase(fout) || fout->dopt->binary_upgrade)
+		return;
+
+	if (tbinfo && tbinfo->dobj.namespace &&
+		strcmp(tbinfo->dobj.namespace->dobj.name, "sys") == 0 &&
+		(strcmp(tbinfo->dobj.name, "babelfish_sysdatabases") == 0 ||
+		 strcmp(tbinfo->dobj.name, "babelfish_namespace_ext") == 0 ||
+		 strcmp(tbinfo->dobj.name, "babelfish_function_ext") == 0 ||
+		 strcmp(tbinfo->dobj.name, "babelfish_authid_login_ext") == 0 ||
+		 strcmp(tbinfo->dobj.name, "babelfish_authid_user_ext") == 0 ||
+		 strcmp(tbinfo->dobj.name, "babelfish_view_def") == 0 ||
+		 strcmp(tbinfo->dobj.name, "babelfish_domain_mapping") == 0))
+	{
+		tbinfo->dobj.dump |= DUMP_COMPONENT_DATA;
+	}
 }
 
 /*
@@ -540,4 +610,203 @@ updateExtConfigArray(Archive *fout, char ***extconfigarray, int nconfigitems)
 
 	PQclear(res);
 	resetPQExpBuffer(query);
+}
+
+/*
+ * prepareForLogicalDatabaseDump:
+ * Checks if provided babelfish logical database exists or not. If the database exists
+ * then we add all the physical schemas corresponding to that database into schema_include_patterns
+ * so that we dump only those physical schemas and all their contained objects.
+ */
+void
+prepareForLogicalDatabaseDump(Archive *fout, SimpleStringList *schema_include_patterns)
+{
+	PQExpBuffer query;
+	PGresult	*res;
+	int			ntups;
+	int			dbid;
+	int			i;
+
+	if (!isBabelfishDatabase(fout))
+	{
+		pg_log_error("\"%s\" is not a Babelfish Database.", fout->dopt->cparams.dbname);
+		exit_nicely(1);
+	}
+
+	query = createPQExpBuffer();
+	/* get dbid of the given babelfish logical database from sys.babelfish_sysdatabases */
+	appendPQExpBuffer(query,
+					  "SELECT dbid "
+					  "FROM sys.babelfish_sysdatabases "
+					  "WHERE name = '%s';",
+					  bbf_db_name);
+	res = ExecuteSqlQuery(fout, query->data, PGRES_TUPLES_OK);
+	if (PQntuples(res) != 1)
+	{
+		pg_log_error("Babelfish database \"%s\" does not exists.", bbf_db_name);
+		exit_nicely(1);
+	}
+
+	dbid = atooid(PQgetvalue(res, 0, PQfnumber(res, "dbid")));
+	PQclear(res);
+	destroyPQExpBuffer(query);
+
+	query = createPQExpBuffer();
+	/* Get all the physical schema names from sys.babelfish_namespace_ext with given dbid */
+	appendPQExpBuffer(query,
+					  "SELECT pg_catalog.quote_ident(nspname) AS nspname "
+					  "FROM sys.babelfish_namespace_ext "
+					  "WHERE dbid = %d;",
+					  dbid);
+	res = ExecuteSqlQuery(fout, query->data, PGRES_TUPLES_OK);
+	ntups = PQntuples(res);
+
+	/*
+	 * Add all physical schemas corresponding to the logical database into
+	 * schema_include_patterns so that we dump only those schemas.
+	 */
+	for (i = 0; i < ntups; i++)
+	{
+		char *schema_name;
+
+		schema_name = pg_strdup(PQgetvalue(res, i, PQfnumber(res, "nspname")));
+		simple_string_list_append(schema_include_patterns, schema_name);
+		pfree(schema_name);
+	}
+
+	PQclear(res);
+	destroyPQExpBuffer(query);
+}
+
+/*
+ * getBabelfishDependencies:
+ * Sets required dependencies for babelfish objects.
+ */
+void
+getBabelfishDependencies(Archive *fout)
+{
+	PQExpBuffer		query;
+	PGresult	   *res;
+	TableInfo	   *sysdb_table;
+	TableInfo	   *namespace_ext_table;
+	DumpableObject *dobj;
+	DumpableObject *refdobj;
+
+	if (!isBabelfishDatabase(fout) || fout->dopt->binary_upgrade)
+		return;
+
+	query = createPQExpBuffer();
+	/* get oids of sys.babelfish_sysdatabases and sys.babelfish_namespace_ext tables */
+	appendPQExpBufferStr(query,
+						 "SELECT oid "
+						 "FROM pg_class "
+						 "WHERE relname in ('babelfish_sysdatabases', 'babelfish_namespace_ext') "
+						 "AND relnamespace = 'sys'::regnamespace "
+						 "ORDER BY relname;");
+	res = ExecuteSqlQuery(fout, query->data, PGRES_TUPLES_OK);
+	
+	Assert(PQntuples(res) == 2);
+	namespace_ext_table = findTableByOid(atooid(PQgetvalue(res, 0, 0)));
+	sysdb_table = findTableByOid(atooid(PQgetvalue(res, 1, 0)));
+	Assert(sysdb_table != NULL && namespace_ext_table != NULL);
+	dobj = (DumpableObject *) namespace_ext_table->dataObj;
+	refdobj = (DumpableObject *) sysdb_table->dataObj;
+	/*
+	 * Make babelfish_namespace_ext table dependent babelfish_sysdatabases
+	 * table so that we dump babelfish_sysdatabases's data before babelfish_namespace_ext.
+	 * This is needed to generate and handle new "dbid" during logical database restore.
+	 */
+	addObjectDependency(dobj, refdobj->dumpId);
+
+	PQclear(res);
+	destroyPQExpBuffer(query);
+}
+
+/*
+ * getCursorForBbfCatalogTableData:
+ * Prepare custom cursor for all Babelfish catalog tables to selectively dump the data
+ * corresponding to specified logical database.
+ */
+void
+getCursorForBbfCatalogTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer buf, int *nfields)
+{
+	PQExpBuffer q = createPQExpBuffer();
+	PGresult   *res;
+	int			i,
+				dbid;
+	bool		is_builtin_db = false;
+
+	if (!isBabelfishDatabase(fout) || bbf_db_name == NULL)
+		return;
+
+	is_builtin_db = pg_strcasecmp(bbf_db_name, "master") == 0 ? true : false;
+
+	if (tbinfo->dobj.namespace == NULL ||
+		strcmp(tbinfo->dobj.namespace->dobj.name, "sys") != 0 ||
+		!(strcmp(tbinfo->dobj.name, "babelfish_sysdatabases") == 0 ||
+		 strcmp(tbinfo->dobj.name, "babelfish_namespace_ext") == 0 ||
+		 strcmp(tbinfo->dobj.name, "babelfish_function_ext") == 0 ||
+		 strcmp(tbinfo->dobj.name, "babelfish_authid_login_ext") == 0 ||
+		 strcmp(tbinfo->dobj.name, "babelfish_authid_user_ext") == 0 ||
+		 strcmp(tbinfo->dobj.name, "babelfish_view_def") == 0 ||
+		 strcmp(tbinfo->dobj.name, "babelfish_domain_mapping") == 0))
+		return;
+
+	appendPQExpBuffer(q, "SELECT dbid FROM sys.babelfish_sysdatabases WHERE name = '%s';", bbf_db_name);
+	res = ExecuteSqlQueryForSingleRow(fout, q->data);
+	dbid = atooid(PQgetvalue(res, 0, 0));
+
+	PQclear(res);
+	destroyPQExpBuffer(q);
+	resetPQExpBuffer(buf);
+	appendPQExpBufferStr(buf, "DECLARE _pg_dump_cursor CURSOR FOR SELECT ");
+	*nfields = 0;
+	for (i = 0; i < tbinfo->numatts; i++)
+	{
+		if (tbinfo->attisdropped[i])
+			continue;
+		if (!is_builtin_db && strcmp(tbinfo->attnames[i], "dbid") == 0)
+			continue;
+		if (*nfields > 0)
+			appendPQExpBufferStr(buf, ", ");
+		appendPQExpBufferStr(buf, "a.");
+		appendPQExpBufferStr(buf, fmtId(tbinfo->attnames[i]));
+		(*nfields)++;
+	}
+
+	if (strcmp(tbinfo->dobj.name, "babelfish_sysdatabases") == 0)
+	{
+		appendPQExpBuffer(buf, " FROM ONLY %s a WHERE a.dbid = %d",
+						  fmtQualifiedDumpable(tbinfo), dbid);
+		if (is_builtin_db)
+			appendPQExpBufferStr(buf, " LIMIT 0");
+	}
+	else if (strcmp(tbinfo->dobj.name, "babelfish_namespace_ext") == 0)
+	{
+		appendPQExpBuffer(buf, " FROM ONLY %s a WHERE a.dbid = %d",
+						  fmtQualifiedDumpable(tbinfo), dbid);
+		if (is_builtin_db)
+			appendPQExpBuffer(buf, " AND a.nspname NOT IN ('%s_dbo', '%s_guest')",
+							  bbf_db_name, bbf_db_name);
+	}
+	else if (strcmp(tbinfo->dobj.name, "babelfish_view_def") == 0)
+		appendPQExpBuffer(buf, " FROM ONLY %s a WHERE a.dbid = %d",
+						  fmtQualifiedDumpable(tbinfo), dbid);
+	else if (strcmp(tbinfo->dobj.name, "babelfish_function_ext") == 0)
+		appendPQExpBuffer(buf, " FROM ONLY %s a "
+						  "INNER JOIN sys.babelfish_namespace_ext b "
+						  "ON a.nspname = b.nspname "
+						  "WHERE b.dbid = %d",
+						  fmtQualifiedDumpable(tbinfo), dbid);
+	else if(strcmp(tbinfo->dobj.name, "babelfish_authid_user_ext") == 0)
+	{
+		appendPQExpBuffer(buf, " FROM ONLY %s a WHERE a.database_name = '%s'",
+						  fmtQualifiedDumpable(tbinfo), bbf_db_name);
+		if (is_builtin_db)
+			appendPQExpBuffer(buf, " AND a.rolname NOT IN ('%s_dbo', '%s_db_owner', '%s_guest')",
+							  bbf_db_name, bbf_db_name, bbf_db_name);
+	}
+	else
+		appendPQExpBuffer(buf, " FROM ONLY %s a",
+						fmtQualifiedDumpable(tbinfo));
 }

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -39,5 +39,6 @@ extern void prepareForLogicalDatabaseDump(Archive *fout, SimpleStringList *schem
 extern void getBabelfishDependencies(Archive *fout);
 extern void dumpBabelGUCs(Archive *fout);
 extern void getCursorForBbfCatalogTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer buf, int *nfields);
+extern void fixCopyCommand(Archive *fout, PQExpBuffer copyBuf, TableInfo *tbinfo, bool isFrom);
 
 #endif

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -20,9 +20,10 @@
 #define PLTSQL_TVFTYPE_MSTVF 1
 #define PLTSQL_TVFTYPE_ITVF  2
 
+extern char *bbf_db_name;
 
-extern char *getMinOid(Archive *fout);
 extern void bbf_selectDumpableCast(CastInfo *cast);
+extern void bbf_selectDumpableTableData(TableInfo *tbinfo, Archive *fout);
 extern void fixTsqlDefaultExpr(Archive *fout, AttrDefInfo *attrDefInfo);
 extern bool isBabelfishDatabase(Archive *fout);
 extern void fixOprRegProc(Archive *fout, const OprInfo *oprinfo, const char *oprleft, const char *oprright, char **oprregproc);
@@ -33,5 +34,10 @@ extern void fixAttoptionsBbfOriginalName(Archive *fout, Oid relOid, const TableI
 extern void setOrResetPltsqlFuncRestoreGUCs(Archive *fout, PQExpBuffer q, const FuncInfo *finfo, char prokind, bool proretset, bool is_set);
 extern void dumpBabelfishSpecificConfig(Archive *AH, const char *dbname, PQExpBuffer outbuf);
 extern void updateExtConfigArray(Archive *fout, char ***extconfigarray, int nconfigitems);
+extern char *babelfish_handle_view_def(Archive *fout, char *view_def);
+extern void prepareForLogicalDatabaseDump(Archive *fout, SimpleStringList *schema_include_patterns);
+extern void getBabelfishDependencies(Archive *fout);
+extern void dumpBabelGUCs(Archive *fout);
+extern void getCursorForBbfCatalogTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer buf, int *nfields);
 
 #endif

--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -1,0 +1,104 @@
+/*-------------------------------------------------------------------------
+ *
+ * Utility routines for babelfish objects
+ *
+ * Portions Copyright (c) 1996-2021, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/bin/pg_dump/dumpall_babel_utils.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres_fe.h"
+
+#include "catalog/pg_class_d.h"
+#include "catalog/pg_proc_d.h"
+#include "catalog/pg_type_d.h"
+#include "common/logging.h"
+#include "dumpall_babel_utils.h"
+#include "fe_utils/string_utils.h"
+#include "pg_backup_db.h"
+#include "pg_backup_utils.h"
+#include "pg_backup.h"
+#include "pg_dump.h"
+#include "pqexpbuffer.h"
+
+/* Babelfish virtual database to dump */
+char *bbf_db_name = NULL;
+
+/*
+ * Returns query to fetch all Babelfish users of specified logical database
+ * and all the logins.
+ * drop_query decides whether the qeury is to DROP the roles.
+ */
+void
+getBabelfishRolesQuery(PQExpBuffer buf, char *role_catalog, bool drop_query)
+{
+	if (!bbf_db_name)
+		return;
+
+	resetPQExpBuffer(buf);
+	if (drop_query)
+	{
+		printfPQExpBuffer(buf,
+						  "WITH bbf_roles AS "
+						  "(SELECT rolname from sys.babelfish_authid_user_ext "
+						  "WHERE database_name = '%s' "
+						  "UNION SELECT rolname from sys.babelfish_authid_login_ext) "
+						  "SELECT rc.rolname "
+						  "FROM %s rc "
+						  "INNER JOIN bbf_roles bc "
+						  "ON rc.rolname = bc.rolname "
+						  "WHERE rc.rolname !~ '^pg_' "
+						  "ORDER BY 1", bbf_db_name, role_catalog);
+	}
+	else
+	{
+		printfPQExpBuffer(buf,
+						  "WITH bbf_roles AS "
+						  "(SELECT rolname from sys.babelfish_authid_user_ext "
+						  "WHERE database_name = '%s' "
+						  "UNION SELECT rolname from sys.babelfish_authid_login_ext) "
+						  "SELECT oid, rc.rolname, rolsuper, rolinherit, "
+						  "rolcreaterole, rolcreatedb, "
+						  "rolcanlogin, rolconnlimit, rolpassword, "
+						  "rolvaliduntil, rolreplication, rolbypassrls, "
+						  "pg_catalog.shobj_description(oid, '%s') as rolcomment, "
+						  "rc.rolname = current_user AS is_current_user "
+						  "FROM %s rc "
+						  "INNER JOIN bbf_roles bc "
+						  "ON rc.rolname = bc.rolname "
+						  "WHERE rc.rolname !~ '^pg_' "
+						  "ORDER BY 2", bbf_db_name, role_catalog, role_catalog);
+	}
+}
+
+/*
+ * Returns query to fetch al the roles, members and grantors related
+ * to Babelfish users and logins.
+ */
+void
+getBabelfishRoleMembershipQuery(PQExpBuffer buf, char *role_catalog)
+{
+	if (!bbf_db_name)
+		return;
+
+	resetPQExpBuffer(buf);
+	printfPQExpBuffer(buf, "WITH bbf_roles AS "
+					  "(SELECT rc.oid, rc.rolname FROM %s rc "
+					  "INNER JOIN sys.babelfish_authid_user_ext bc "
+					  "ON rc.rolname = bc.rolname WHERE bc.database_name = '%s' "
+					  "UNION SELECT rc.oid, rc.rolname FROM %s rc "
+					  "INNER JOIN sys.babelfish_authid_login_ext bc "
+					  "ON rc.rolname = bc.rolname) "
+					  "SELECT ur.rolname AS roleid, "
+					  "um.rolname AS member, "
+					  "a.admin_option, "
+					  "ug.rolname AS grantor "
+					  "FROM pg_auth_members a "
+					  "INNER JOIN bbf_roles ur on ur.oid = a.roleid "
+					  "INNER JOIN bbf_roles um on um.oid = a.member "
+					  "LEFT JOIN bbf_roles ug on ug.oid = a.grantor "
+					  "WHERE NOT (ur.rolname ~ '^pg_' AND um.rolname ~ '^pg_')"
+					  "ORDER BY 1,2,3", role_catalog, bbf_db_name, role_catalog);
+}

--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -34,8 +34,17 @@ char *bbf_db_name = NULL;
 void
 getBabelfishRolesQuery(PQExpBuffer buf, char *role_catalog, bool drop_query)
 {
+	char *escaped_bbf_db_name;
+
 	if (!bbf_db_name)
 		return;
+
+	/*
+	 * Get escaped bbf_db_name to handle special characters in it.
+	 * 2*strlen+1 bytes are required for PQescapeString according to the documentation.
+	 */
+	escaped_bbf_db_name = pg_malloc(2 * strlen(bbf_db_name) + 1);
+	PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
 
 	resetPQExpBuffer(buf);
 	if (drop_query)
@@ -50,7 +59,7 @@ getBabelfishRolesQuery(PQExpBuffer buf, char *role_catalog, bool drop_query)
 						  "INNER JOIN bbf_roles bc "
 						  "ON rc.rolname = bc.rolname "
 						  "WHERE rc.rolname !~ '^pg_' "
-						  "ORDER BY 1", bbf_db_name, role_catalog);
+						  "ORDER BY 1", escaped_bbf_db_name, role_catalog);
 	}
 	else
 	{
@@ -69,7 +78,7 @@ getBabelfishRolesQuery(PQExpBuffer buf, char *role_catalog, bool drop_query)
 						  "INNER JOIN bbf_roles bc "
 						  "ON rc.rolname = bc.rolname "
 						  "WHERE rc.rolname !~ '^pg_' "
-						  "ORDER BY 2", bbf_db_name, role_catalog, role_catalog);
+						  "ORDER BY 2", escaped_bbf_db_name, role_catalog, role_catalog);
 	}
 }
 
@@ -80,8 +89,17 @@ getBabelfishRolesQuery(PQExpBuffer buf, char *role_catalog, bool drop_query)
 void
 getBabelfishRoleMembershipQuery(PQExpBuffer buf, char *role_catalog)
 {
+	char *escaped_bbf_db_name;
+
 	if (!bbf_db_name)
 		return;
+
+	/*
+	 * Get escaped bbf_db_name to handle special characters in it.
+	 * 2*strlen+1 bytes are required for PQescapeString according to the documentation.
+	 */
+	escaped_bbf_db_name = pg_malloc(2 * strlen(bbf_db_name) + 1);
+	PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
 
 	resetPQExpBuffer(buf);
 	printfPQExpBuffer(buf, "WITH bbf_roles AS "
@@ -100,5 +118,5 @@ getBabelfishRoleMembershipQuery(PQExpBuffer buf, char *role_catalog)
 					  "INNER JOIN bbf_roles um on um.oid = a.member "
 					  "LEFT JOIN bbf_roles ug on ug.oid = a.grantor "
 					  "WHERE NOT (ur.rolname ~ '^pg_' AND um.rolname ~ '^pg_')"
-					  "ORDER BY 1,2,3", role_catalog, bbf_db_name, role_catalog);
+					  "ORDER BY 1,2,3", role_catalog, escaped_bbf_db_name, role_catalog);
 }

--- a/src/bin/pg_dump/dumpall_babel_utils.h
+++ b/src/bin/pg_dump/dumpall_babel_utils.h
@@ -1,0 +1,22 @@
+/*-------------------------------------------------------------------------
+ *
+ * Utility routines for babelfish objects
+ *
+ * Portions Copyright (c) 1996-2021, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/bin/pg_dump/dumpall_babel_utils.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef DUMPALL_BABEL_UTILS_H
+#define DUMPALL_BABEL_UTILS_H
+
+#include "pqexpbuffer.h"
+
+extern char *bbf_db_name;
+
+extern void getBabelfishRolesQuery(PQExpBuffer buf, char *role_catalog, bool drop_query);
+extern void getBabelfishRoleMembershipQuery(PQExpBuffer buf, char *role_catalog);
+
+#endif

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -146,6 +146,9 @@ static int	ncomments = 0;
 static SecLabelItem *seclabels = NULL;
 static int	nseclabels = 0;
 
+/* Babelfish logical database to dump */
+char *bbf_db_name = NULL;
+
 /*
  * The default number of rows per INSERT when
  * --inserts is specified without --rows-per-insert
@@ -413,6 +416,7 @@ main(int argc, char **argv)
 		{"on-conflict-do-nothing", no_argument, &dopt.do_nothing, 1},
 		{"rows-per-insert", required_argument, NULL, 10},
 		{"include-foreign-data", required_argument, NULL, 11},
+		{"bbf-database-name", required_argument, NULL, 12},
 
 		{NULL, 0, NULL, 0}
 	};
@@ -623,6 +627,11 @@ main(int argc, char **argv)
 										  optarg);
 				break;
 
+			case 12:			/* Babelfish logical database name */
+				bbf_db_name = pg_strdup(optarg);
+				dopt.include_everything = false;
+				break;
+
 			default:
 				/* getopt_long already emitted a complaint */
 				pg_log_error_hint("Try \"%s --help\" for more information.", progname);
@@ -760,6 +769,9 @@ main(int argc, char **argv)
 	g_last_builtin_oid = FirstNormalObjectId - 1;
 
 	pg_log_info("last built-in OID is %u", g_last_builtin_oid);
+
+	if (bbf_db_name != NULL)
+		prepareForLogicalDatabaseDump(fout, &schema_include_patterns);
 
 	/* Expand schema selection patterns into OID lists */
 	if (schema_include_patterns.head != NULL)
@@ -905,6 +917,8 @@ main(int argc, char **argv)
 	/* The database items are always next, unless we don't want them at all */
 	if (dopt.outputCreateDB)
 		dumpDatabase(fout);
+
+	dumpBabelGUCs(fout);
 
 	/* Now the rearrangeable objects. */
 	for (i = 0; i < numObjs; i++)
@@ -2166,6 +2180,7 @@ dumpTableData_insert(Archive *fout, const void *dcontext)
 	if (tdinfo->filtercond)
 		appendPQExpBuffer(q, " %s", tdinfo->filtercond);
 
+	getCursorForBbfCatalogTableData(fout, tbinfo, q, &nfields);
 	ExecuteSqlStatement(fout, q->data);
 
 	while (1)
@@ -6485,6 +6500,9 @@ getTables(Archive *fout, int *numTables)
 		else
 			selectDumpableTable(&tblinfo[i], fout);
 
+		if (bbf_db_name != NULL)
+			bbf_selectDumpableTableData(&tblinfo[i], fout);
+
 		/*
 		 * Now, consider the table "interesting" if we need to dump its
 		 * definition or its data.  Later on, we'll skip a lot of data
@@ -10089,14 +10107,6 @@ dumpExtension(Archive *fout, const ExtensionInfo *extinfo)
 	delq = createPQExpBuffer();
 
 	qextname = pg_strdup(fmtId(extinfo->dobj.name));
-
-	if (strstr(qextname, "babelfishpg_common") && isBabelfishDatabase(fout))
-	{
-		char *oid = getMinOid(fout);
-		appendPQExpBuffer(q, "SET babelfishpg_tsql.dump_restore = TRUE;\n");
-		appendPQExpBuffer(q, "SET babelfishpg_tsql.dump_restore_min_oid = %s;\n", oid);
-		free(oid);
-	}
 
 	appendPQExpBuffer(delq, "DROP EXTENSION %s;\n", qextname);
 
@@ -17892,6 +17902,9 @@ getDependencies(Archive *fout)
 		/* Standalone T-SQL table-type as a function's argument or multi-statement TVF */
 		fixTsqlTableTypeDependency(fout, dobj, refdobj, deptype);
 	}
+	
+	if (bbf_db_name != NULL)
+		getBabelfishDependencies(fout);
 
 	PQclear(res);
 

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -99,4 +99,7 @@ extern List *CopyGetAttnums(TupleDesc tupDesc, Relation rel,
 
 typedef bool (*is_tsql_rowversion_or_timestamp_datatype_hook_type)(Oid oid);
 extern PGDLLIMPORT is_tsql_rowversion_or_timestamp_datatype_hook_type is_tsql_rowversion_or_timestamp_datatype_hook;
+typedef void (*fill_missing_values_in_copyfrom_hook_type)(Relation rel, Datum *values, bool *nulls);
+extern PGDLLIMPORT fill_missing_values_in_copyfrom_hook_type fill_missing_values_in_copyfrom_hook;
+
 #endif							/* COPY_H */


### PR DESCRIPTION
### Description
Added support for dumping a single Babelfish logical database. Changes are
summarized in following bullet points:
1. Added a new option `--bbf-db-name` in both pg_dumpall and pg_dump to
let user provide the name of logical database to be dumped.
2. Fetch all the physical schema names corresponding to the given logical database
and add all of them into `schema_include_patterns` list. With this, existing dump
logic will make sure to only dump all these schemas as well as all the objects
contained by these schemas.
3. Function `bbf_selectDumpableTableData` takes care of explicitly marking all
Babelfish catalog table data to be dumped.
4. We need to selectively dump the Babelfish catalog table data corresponding to
given logical database which is being handled by function `getCursorForBbfCatalogTableData`
for `COLUMN-INSERT` and `fixCopyCommand` for `COPY`. These function prepares
query using joins and conditions to filter the data.
5. We skip dumping the `dbid` column as it might conflict with the existing database's `dbid`
so we generate the new `dbid` during restore. It has been handled for both `COLUMN-INSERT`
and `COPY` options:
 a. `COPY`: Implemented a hook `fill_missing_values_in_copyfrom_hook` which will use the
 sequence to generate the new `dbid`.  
 b. `COLUMN-INSERT`: Used existing `pre_parse_analyze_hook` hook to handle this case.
5. Added a new file `dumpall_babel_utils.c` to implement Babelfish specific logic to
selectively dump users/logins. New file is needed since existing `dump_babel_utils.c` can't
be used with pg_dumpall utility.
7. Logins do not belong to a single database so we will be dumping all the logins so it
might be possible that some logins are already present in the target database during restore.
Due to this `CREATE` and `INSERT` might fail for certain logins but it should be fine.
8. Due to the above fact we will always dump logins data using `INSERT` method which is
safe in case one insert fails all other inserts will still go through but COPY will result in whole
batch abort.
9. Current implementation does not dump foreign servers and foreign data wrappers but we
will take it as a future improvement.

Task: BABEL-3870
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>
