### PR TITLE
Merge conflict in b3a0d8324cf1f02c04a7099a436cfd68cfbf4566 Move snowball_create.sql creation into perl file

### DIFF
--- a/src/backend/snowball/Makefile
+++ b/src/backend/snowball/Makefile
@@ -72,40 +72,23 @@ OBJS += \
 	stem_UTF_8_turkish.o \
 	stem_UTF_8_yiddish.o
 
-# first column is language name and also name of dictionary for not-all-ASCII
-# words, second is name of dictionary for all-ASCII words
-# Note order dependency: use of some other language as ASCII dictionary
-# must come after creation of that language
-LANGUAGES=  \
-	arabic		arabic		\
-	armenian	armenian	\
-	basque		basque		\
-	catalan		catalan		\
-	danish		danish		\
-	dutch		dutch		\
-	english		english		\
-	finnish		finnish		\
-	french		french		\
-	german		german		\
-	greek		greek		\
-	hindi		english		\
-	hungarian	hungarian	\
-	indonesian	indonesian	\
-	irish		irish		\
-	italian		italian		\
-	lithuanian	lithuanian	\
-	nepali		nepali		\
-	norwegian	norwegian	\
-	portuguese	portuguese	\
-	romanian	romanian	\
-	russian		english		\
-	serbian		serbian		\
-	spanish		spanish		\
-	swedish		swedish		\
-	tamil		tamil		\
-	turkish		turkish		\
-	yiddish		yiddish
-
+stop_files = \
+	danish.stop \
+	dutch.stop \
+	english.stop \
+	finnish.stop \
+	french.stop \
+	german.stop \
+	hungarian.stop \
+	italian.stop \
+	nepali.stop \
+	norwegian.stop \
+	portuguese.stop \
+	russian.stop \
+	spanish.stop \
+	swedish.stop \
+	tsql_contains.stop \
+	turkish.stop
 
 SQLSCRIPT= snowball_create.sql
 DICTDIR=tsearch_data
@@ -119,58 +102,24 @@ all: all-shared-lib $(SQLSCRIPT)
 
 include $(top_srcdir)/src/Makefile.shlib
 
-$(SQLSCRIPT): Makefile snowball_func.sql.in snowball.sql.in
-	echo '-- Language-specific snowball dictionaries' > $@
-	cat $(srcdir)/snowball_func.sql.in >> $@
-	@set -e; \
-	set $(LANGUAGES) ; \
-	while [ "$$#" -gt 0 ] ; \
-	do \
-		lang=$$1; shift; \
-		nonascdictname=$$lang; \
-		ascdictname=$$1; shift; \
-		if [ -s $(srcdir)/stopwords/$${lang}.stop ] ; then \
-			stop=", StopWords=$${lang}" ; \
-		else \
-			stop=""; \
-		fi; \
-		cat $(srcdir)/snowball.sql.in | \
-			sed -e "s#_LANGNAME_#$$lang#g" | \
-			sed -e "s#_DICTNAME_#$${lang}_stem#g" | \
-			sed -e "s#_CFGNAME_#$$lang#g" | \
-			sed -e "s#_ASCDICTNAME_#$${ascdictname}_stem#g" | \
-			sed -e "s#_NONASCDICTNAME_#$${nonascdictname}_stem#g" | \
-			sed -e "s#_STOPWORDS_#$$stop#g" ; \
-	done >> $@
+$(SQLSCRIPT): snowball_create.pl snowball_func.sql.in snowball.sql.in
+	$(PERL) $< --input ${srcdir} --outdir .
+
+distprep: $(SQLSCRIPT)
 
 install: all installdirs install-lib
 	$(INSTALL_DATA) $(SQLSCRIPT) '$(DESTDIR)$(datadir)'
-	@set -e; \
-	set $(LANGUAGES) ; \
-	while [ "$$#" -gt 0 ] ; \
-	do \
-		lang=$$1; shift; shift; \
-		$(INSTALL_DATA) $(srcdir)/stopwords/tsql_contains.stop '$(DESTDIR)$(datadir)/$(DICTDIR)' ; \
-		if [ -s $(srcdir)/stopwords/$${lang}.stop ] ; then \
-			$(INSTALL_DATA) $(srcdir)/stopwords/$${lang}.stop '$(DESTDIR)$(datadir)/$(DICTDIR)' ; \
-		fi \
-	done
+	$(INSTALL_DATA) $(addprefix $(srcdir)/stopwords/,$(stop_files)) '$(DESTDIR)$(datadir)/$(DICTDIR)'
 
 installdirs: installdirs-lib
 	$(MKDIR_P) '$(DESTDIR)$(datadir)' '$(DESTDIR)$(datadir)/$(DICTDIR)'
 
 uninstall: uninstall-lib
 	rm -f '$(DESTDIR)$(datadir)/$(SQLSCRIPT)'
-	@set -e; \
-	set $(LANGUAGES) ; \
-	while [ "$$#" -gt 0 ] ; \
-	do \
-		lang=$$1; shift; shift;  \
-		rm -f '$(DESTDIR)$(datadir)/$(DICTDIR)/'tsql_contains.stop ; \
-		if [ -s $(srcdir)/stopwords/$${lang}.stop ] ; then \
-		    rm -f '$(DESTDIR)$(datadir)/$(DICTDIR)/'$${lang}.stop ; \
-		fi \
-	done
+	rm -f $(addprefix '$(DESTDIR)$(datadir)/$(DICTDIR)/',$(stop_files))
 
-clean distclean maintainer-clean: clean-lib
-	rm -f $(OBJS) $(SQLSCRIPT)
+clean distclean: clean-lib
+	rm -f $(OBJS)
+
+maintainer-clean: distclean
+	rm -f $(SQLSCRIPT)

--- a/src/backend/snowball/snowball_create.pl
+++ b/src/backend/snowball/snowball_create.pl
@@ -1,0 +1,148 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Getopt::Long;
+
+my $outdir_path = '';
+my $makefile_path = '';
+my $input_path = '';
+my $depfile;
+
+our @languages = qw(
+	arabic
+	armenian
+	basque
+	catalan
+	danish
+	dutch
+	english
+	finnish
+	french
+	german
+	greek
+	hindi
+	hungarian
+	indonesian
+	irish
+	italian
+	lithuanian
+	nepali
+	norwegian
+	portuguese
+	romanian
+	russian
+	serbian
+	spanish
+	swedish
+	tamil
+	turkish
+	yiddish
+);
+
+# Names of alternative dictionaries for all-ASCII words.  If not
+# listed, the language itself is used.  Note order dependency: Use of
+# some other language as ASCII dictionary must come after creation of
+# that language, so the "backup" language must be listed earlier in
+# @languages.
+
+our %ascii_languages = (
+	'hindi' => 'english',
+	'russian' => 'english',
+);
+
+GetOptions(
+	'depfile'    => \$depfile,
+	'outdir:s'   => \$outdir_path,
+	'input:s'    => \$input_path) || usage();
+
+# Make sure input_path ends in a slash if needed.
+if ($input_path ne '' && substr($input_path, -1) ne '/')
+{
+	$outdir_path .= '/';
+}
+
+# Make sure outdir_path ends in a slash if needed.
+if ($outdir_path ne '' && substr($outdir_path, -1) ne '/')
+{
+	$outdir_path .= '/';
+}
+
+GenerateTsearchFiles();
+
+sub usage
+{
+	die <<EOM;
+Usage: snowball_create.pl --input/-i <path> --outdir/-o <path>
+    --depfile       Write dependency file
+    --outdir        Output directory (default '.')
+    --input         Input directory
+
+snowball_create.pl creates snowball.sql from snowball.sql.in
+EOM
+}
+
+sub GenerateTsearchFiles
+{
+	my $target = shift;
+	my $outdir_file = "$outdir_path/snowball_create.sql";
+
+	my $F;
+	my $D;
+	my $tmpl = read_file("$input_path/snowball.sql.in");
+
+	if ($depfile)
+	{
+		open($D, '>', "$outdir_path/snowball_create.dep")
+		  || die "Could not write snowball_create.dep";
+	}
+
+	print $D "$outdir_file: $input_path/snowball.sql.in\n" if $depfile;
+	print $D "$outdir_file: $input_path/snowball_func.sql.in\n" if $depfile;
+
+	open($F, '>', $outdir_file)
+	  || die "Could not write snowball_create.sql";
+
+	print $F "-- Language-specific snowball dictionaries\n";
+
+	print $F read_file("$input_path/snowball_func.sql.in");
+
+	foreach my $lang (@languages)
+	{
+		my $asclang = $ascii_languages{$lang} || $lang;
+		my $txt     = $tmpl;
+		my $stop    = '';
+		my $stopword_path = "$input_path/stopwords/$lang.stop";
+
+		if (-s "$stopword_path")
+		{
+			$stop = ", StopWords=$lang";
+
+			print $D "$outdir_file: $stopword_path\n" if $depfile;
+		}
+
+		$txt =~ s#_LANGNAME_#${lang}#gs;
+		$txt =~ s#_DICTNAME_#${lang}_stem#gs;
+		$txt =~ s#_CFGNAME_#${lang}#gs;
+		$txt =~ s#_ASCDICTNAME_#${asclang}_stem#gs;
+		$txt =~ s#_NONASCDICTNAME_#${lang}_stem#gs;
+		$txt =~ s#_STOPWORDS_#$stop#gs;
+		print $F $txt;
+	}
+	close($F);
+	close($D) if $depfile;
+	return;
+}
+
+
+sub read_file
+{
+	my $filename = shift;
+	my $F;
+	local $/ = undef;
+	open($F, '<', $filename) || die "Could not open file $filename\n";
+	my $txt = <$F>;
+	close($F);
+
+	return $txt;
+}

--- a/src/tools/msvc/Install.pm
+++ b/src/tools/msvc/Install.pm
@@ -389,39 +389,9 @@ sub GenerateTsearchFiles
 	my $target = shift;
 
 	print "Generating tsearch script...";
-	my $F;
-	my $tmpl = read_file('src/backend/snowball/snowball.sql.in');
-	my $mf   = read_file('src/backend/snowball/Makefile');
-	$mf =~ s{\\\r?\n}{}g;
-	$mf =~ /^LANGUAGES\s*=\s*(.*)$/m
-	  || die "Could not find LANGUAGES line in snowball Makefile\n";
-	my @pieces = split /\s+/, $1;
-	open($F, '>', "$target/share/snowball_create.sql")
-	  || die "Could not write snowball_create.sql";
-	print $F read_file('src/backend/snowball/snowball_func.sql.in');
-
-	while ($#pieces > 0)
-	{
-		my $lang    = shift @pieces || last;
-		my $asclang = shift @pieces || last;
-		my $txt     = $tmpl;
-		my $stop    = '';
-
-		if (-s "src/backend/snowball/stopwords/$lang.stop")
-		{
-			$stop = ", StopWords=$lang";
-		}
-
-		$txt =~ s#_LANGNAME_#${lang}#gs;
-		$txt =~ s#_DICTNAME_#${lang}_stem#gs;
-		$txt =~ s#_CFGNAME_#${lang}#gs;
-		$txt =~ s#_ASCDICTNAME_#${asclang}_stem#gs;
-		$txt =~ s#_NONASCDICTNAME_#${lang}_stem#gs;
-		$txt =~ s#_STOPWORDS_#$stop#gs;
-		print $F $txt;
-		print ".";
-	}
-	close($F);
+	system('perl', 'src/backend/snowball/snowball_create.pl',
+		'--input', 'src/backend/snowball/',
+		'--outdir', "$target/share/");
 	print "\n";
 	return;
 }


### PR DESCRIPTION
Conflict occurs due to changing how the snowball dicts are compiled when we had modified the Makefile to add tsql_contains.stop. Resolved by taking in new changes in the Makefile and adding in an extra reference to `tsql_contains` in the newly created stop file list in the Makefile.

Extension PR for validation: https://github.com/amazon-aurora/babelfish_extensions/pull/54

```
Merge conflict in src/backend/snowball/Makefile
install: all installdirs install-lib
	$(INSTALL_DATA) $(SQLSCRIPT) '$(DESTDIR)$(datadir)'
<<<<<<< ours
	@set -e; \
	set $(LANGUAGES) ; \
	while [ "$$#" -gt 0 ] ; \
	do \
		lang=$$1; shift; shift; \
		$(INSTALL_DATA) $(srcdir)/stopwords/tsql_contains.stop '$(DESTDIR)$(datadir)/$(DICTDIR)' ; \
		if [ -s $(srcdir)/stopwords/$${lang}.stop ] ; then \
			$(INSTALL_DATA) $(srcdir)/stopwords/$${lang}.stop '$(DESTDIR)$(datadir)/$(DICTDIR)' ; \
		fi \
	done
=======
	$(INSTALL_DATA) $(addprefix $(srcdir)/stopwords/,$(stop_files)) '$(DESTDIR)$(datadir)/$(DICTDIR)'

uninstall: uninstall-lib
	rm -f '$(DESTDIR)$(datadir)/$(SQLSCRIPT)'
<<<<<<< ours
	@set -e; \
	set $(LANGUAGES) ; \
	while [ "$$#" -gt 0 ] ; \
	do \
		lang=$$1; shift; shift;  \
		rm -f '$(DESTDIR)$(datadir)/$(DICTDIR)/'tsql_contains.stop ; \
		if [ -s $(srcdir)/stopwords/$${lang}.stop ] ; then \
		    rm -f '$(DESTDIR)$(datadir)/$(DICTDIR)/'$${lang}.stop ; \
		fi \
	done

clean distclean maintainer-clean: clean-lib
	rm -f $(OBJS) $(SQLSCRIPT)
=======
	rm -f $(addprefix '$(DESTDIR)$(datadir)/$(DICTDIR)/',$(stop_files))

clean distclean: clean-lib
	rm -f $(OBJS)

maintainer-clean: distclean
	rm -f $(SQLSCRIPT)
>>>>>>> theirs
```