### PR TITLE
Merge conflict in d951052a9e02bfacad8bd6f0f53a4dcd3b7e6d1f Allow parallel workers to retrieve some data from Port

### DIFF
--- a/src/backend/access/transam/parallel.c
+++ b/src/backend/access/transam/parallel.c
@@ -76,6 +76,7 @@
 #define PARALLEL_KEY_REINDEX_STATE			UINT64CONST(0xFFFFFFFFFFFF000C)
 #define PARALLEL_KEY_RELMAPPER_STATE		UINT64CONST(0xFFFFFFFFFFFF000D)
 #define PARALLEL_KEY_UNCOMMITTEDENUMS		UINT64CONST(0xFFFFFFFFFFFF000E)
+#define PARALLEL_KEY_CLIENTCONNINFO			UINT64CONST(0xFFFFFFFFFFFF000F)
 
 /* Fixed-size parallel state. */
 typedef struct FixedParallelState
@@ -212,6 +213,7 @@ InitializeParallelDSM(ParallelContext *pcxt)
 	Size		reindexlen = 0;
 	Size		relmapperlen = 0;
 	Size		uncommittedenumslen = 0;
+	Size		clientconninfolen = 0;
 	Size		segsize = 0;
 	int			i;
 	FixedParallelState *fps;
@@ -272,8 +274,10 @@ InitializeParallelDSM(ParallelContext *pcxt)
 		shm_toc_estimate_chunk(&pcxt->estimator, relmapperlen);
 		uncommittedenumslen = EstimateUncommittedEnumsSpace();
 		shm_toc_estimate_chunk(&pcxt->estimator, uncommittedenumslen);
+		clientconninfolen = EstimateClientConnectionInfoSpace();
+		shm_toc_estimate_chunk(&pcxt->estimator, clientconninfolen);
 		/* If you add more chunks here, you probably need to add keys. */
-		shm_toc_estimate_keys(&pcxt->estimator, 11);
+		shm_toc_estimate_keys(&pcxt->estimator, 12);
 
 		/* Estimate space need for error queues. */
 		StaticAssertStmt(BUFFERALIGN(PARALLEL_ERROR_QUEUE_SIZE) ==
@@ -352,6 +356,7 @@ InitializeParallelDSM(ParallelContext *pcxt)
 		char	   *session_dsm_handle_space;
 		char	   *entrypointstate;
 		char	   *uncommittedenumsspace;
+		char	   *clientconninfospace;
 		Size		lnamelen;
 
 		/* Serialize shared libraries we have loaded. */
@@ -421,6 +426,12 @@ InitializeParallelDSM(ParallelContext *pcxt)
 		SerializeUncommittedEnums(uncommittedenumsspace, uncommittedenumslen);
 		shm_toc_insert(pcxt->toc, PARALLEL_KEY_UNCOMMITTEDENUMS,
 					   uncommittedenumsspace);
+
+		/* Serialize our ClientConnectionInfo. */
+		clientconninfospace = shm_toc_allocate(pcxt->toc, clientconninfolen);
+		SerializeClientConnectionInfo(clientconninfolen, clientconninfospace);
+		shm_toc_insert(pcxt->toc, PARALLEL_KEY_CLIENTCONNINFO,
+					   clientconninfospace);
 
 		/* Allocate space for worker information. */
 		pcxt->worker = palloc0(sizeof(ParallelWorkerInfo) * pcxt->nworkers);
@@ -1270,6 +1281,7 @@ ParallelWorkerMain(Datum main_arg)
 	char	   *reindexspace;
 	char	   *relmapperspace;
 	char	   *uncommittedenumsspace;
+	char	   *clientconninfospace;
 	StringInfoData msgbuf;
 	char	   *session_dsm_handle_space;
 	Snapshot	tsnapshot;
@@ -1478,6 +1490,11 @@ ParallelWorkerMain(Datum main_arg)
 	uncommittedenumsspace = shm_toc_lookup(toc, PARALLEL_KEY_UNCOMMITTEDENUMS,
 										   false);
 	RestoreUncommittedEnums(uncommittedenumsspace);
+
+	/* Restore the ClientConnectionInfo. */
+	clientconninfospace = shm_toc_lookup(toc, PARALLEL_KEY_CLIENTCONNINFO,
+										 false);
+	RestoreClientConnectionInfo(clientconninfospace);
 
 	/* Attach to the leader's serializable transaction, if SERIALIZABLE. */
 	AttachSerializableXact(fps->serializable_xact_handle);

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -4478,6 +4478,7 @@ BackendInitialize(Port *port)
 
 	/* Save port etc. for ps status */
 	MyProcPort = port;
+	memset(&MyClientConnectionInfo, 0, sizeof(MyClientConnectionInfo));
 
 	/* Tell fd.c about the long-lived FD associated with the port */
 	ReserveExternalFD();

--- a/src/include/libpq/libpq-be.h
+++ b/src/include/libpq/libpq-be.h
@@ -119,6 +119,37 @@ typedef struct ProtocolExtensionConfig {
 } ProtocolExtensionConfig;
 
 /*
+ * ClientConnectionInfo includes the fields describing the client connection
+ * that are copied over to parallel workers as nothing from Port does that.
+ * The same rules apply for allocations here as for Port (everything must be
+ * malloc'd or palloc'd in TopMemoryContext).
+ *
+ * If you add a struct member here, remember to also handle serialization in
+ * SerializeClientConnectionInfo() and co.
+ */
+typedef struct ClientConnectionInfo
+{
+	/*
+	 * Authenticated identity.  The meaning of this identifier is dependent on
+	 * auth_method; it is the identity (if any) that the user presented during
+	 * the authentication cycle, before they were assigned a database role.
+	 * (It is effectively the "SYSTEM-USERNAME" of a pg_ident usermap --
+	 * though the exact string in use may be different, depending on pg_hba
+	 * options.)
+	 *
+	 * authn_id is NULL if the user has not actually been authenticated, for
+	 * example if the "trust" auth method is in use.
+	 */
+	const char *authn_id;
+
+	/*
+	 * The HBA method that determined the above authn_id.  This only has
+	 * meaning if authn_id is not NULL; otherwise it's undefined.
+	 */
+	UserAuth	auth_method;
+} ClientConnectionInfo;
+
+/*
  * This is used by the postmaster in its communication with frontends.  It
  * contains all state information needed during this communication before the
  * backend is run.  The Port structure is kept in malloc'd memory and is
@@ -179,19 +210,6 @@ typedef struct Port
 	 * Information that needs to be held during the authentication cycle.
 	 */
 	HbaLine    *hba;
-
-	/*
-	 * Authenticated identity.  The meaning of this identifier is dependent on
-	 * hba->auth_method; it is the identity (if any) that the user presented
-	 * during the authentication cycle, before they were assigned a database
-	 * role.  (It is effectively the "SYSTEM-USERNAME" of a pg_ident usermap
-	 * -- though the exact string in use may be different, depending on pg_hba
-	 * options.)
-	 *
-	 * authn_id is NULL if the user has not actually been authenticated, for
-	 * example if the "trust" auth method is in use.
-	 */
-	const char *authn_id;
 
 	/*
 	 * TCP keepalive and user timeout settings.
@@ -349,6 +367,7 @@ extern ssize_t be_gssapi_write(Port *port, void *ptr, size_t len);
 #endif							/* ENABLE_GSS */
 
 extern PGDLLIMPORT ProtocolVersion FrontendProtocol;
+extern PGDLLIMPORT ClientConnectionInfo MyClientConnectionInfo;
 
 /* TCP keepalives configuration. These are no-ops on an AF_UNIX socket. */
 

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -484,6 +484,10 @@ extern bool has_rolreplication(Oid roleid);
 typedef void (*shmem_request_hook_type) (void);
 extern PGDLLEXPORT shmem_request_hook_type shmem_request_hook;
 
+extern Size EstimateClientConnectionInfoSpace(void);
+extern void SerializeClientConnectionInfo(Size maxsize, char *start_address);
+extern void RestoreClientConnectionInfo(char *conninfo);
+
 /* in executor/nodeHash.c */
 extern size_t get_hash_memory_limit(void);
 

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -373,6 +373,7 @@ CkptTsStatus
 ClientAuthentication_hook_type
 ClientCertMode
 ClientCertName
+ClientConnectionInfo
 ClientData
 ClonePtrType
 ClosePortalStmt
@@ -2456,6 +2457,7 @@ SerCommitSeqNo
 SerialControl
 SerializableXactHandle
 SerializedActiveRelMaps
+SerializedClientConnectionInfo
 SerializedRanges
 SerializedReindexState
 SerializedSnapshotData


### PR DESCRIPTION
Merge conflict due to both adding a new struct in `src/include/libpq/libpq-be.h` Resolved by taking in both changes and fixing up the comment headers.

Extension PR for validation: https://github.com/amazon-aurora/babelfish_extensions/pull/54

```
Merge conflict in src/include/libpq/libpq-be.h
<<<<<<< ours
 * ProtocolExtensionConfig
 *
 * 	All the callbacks implementing a specific wire protocol
 */
typedef struct ProtocolExtensionConfig {
	int		(*fn_accept)(pgsocket server_fd, struct Port *port);
	void	(*fn_close)(pgsocket server_fd);
	void	(*fn_init)(void);
	int		(*fn_start)(struct Port *port);
	void	(*fn_authenticate)(struct Port *port, const char **username);
	void	(*fn_mainfunc)(struct Port *port) pg_attribute_noreturn();
	void	(*fn_send_message)(ErrorData *edata);
	void	(*fn_send_cancel_key)(int pid, int32 key);
	void	(*fn_comm_reset)(void);
	bool	(*fn_is_reading_msg)(void);
	void	(*fn_send_ready_for_query)(CommandDest dest);
	int		(*fn_read_command)(StringInfo inBuf);
	void	(*fn_end_command)(QueryCompletion *qc, CommandDest dest);
	bool	(*fn_printtup)(TupleTableSlot *slot, DestReceiver *self);
	void	(*fn_printtup_startup)(DestReceiver *self, int operation,
								   TupleDesc typeinfo);
	void	(*fn_printtup_shutdown)(DestReceiver *self);
	void	(*fn_printtup_destroy)(DestReceiver *self);
	int		(*fn_process_command)(void);
	void	(*fn_report_param_status)(const char *name, char *val);
} ProtocolExtensionConfig;
=======
 * ClientConnectionInfo includes the fields describing the client connection
 * that are copied over to parallel workers as nothing from Port does that.
 * The same rules apply for allocations here as for Port (everything must be
 * malloc'd or palloc'd in TopMemoryContext).
 *
 * If you add a struct member here, remember to also handle serialization in
 * SerializeClientConnectionInfo() and co.
 */
typedef struct ClientConnectionInfo
{
	/*
	 * Authenticated identity.  The meaning of this identifier is dependent on
	 * auth_method; it is the identity (if any) that the user presented during
	 * the authentication cycle, before they were assigned a database role.
	 * (It is effectively the "SYSTEM-USERNAME" of a pg_ident usermap --
	 * though the exact string in use may be different, depending on pg_hba
	 * options.)
	 *
	 * authn_id is NULL if the user has not actually been authenticated, for
	 * example if the "trust" auth method is in use.
	 */
	const char *authn_id;

	/*
	 * The HBA method that determined the above authn_id.  This only has
	 * meaning if authn_id is not NULL; otherwise it's undefined.
	 */
	UserAuth	auth_method;
} ClientConnectionInfo;
>>>>>>> theirs
```