### PR TITLE
Support db_datareader/db_datawriter

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -53,9 +53,9 @@ typedef enum {
 static babelfish_status bbf_status = NONE;
 
 static char *default_bbf_db_principals =
-			"('master_dbo', 'master_db_owner', 'master_guest', 'master_db_accessadmin', "
-			"'msdb_dbo', 'msdb_db_owner', 'msdb_guest', 'msdb_db_accessadmin', "
-			"'tempdb_dbo', 'tempdb_db_owner', 'tempdb_guest', 'tempdb_db_accessadmin') ";
+			"('master_dbo', 'master_db_owner', 'master_guest', 'master_db_accessadmin', 'master_db_datareader', 'master_db_datawriter', "
+			"'msdb_dbo', 'msdb_db_owner', 'msdb_guest', 'msdb_db_accessadmin', 'msdb_db_datareader', 'msdb_db_datawriter', "
+			"'tempdb_dbo', 'tempdb_db_owner', 'tempdb_guest', 'tempdb_db_accessadmin', 'tempdb_db_datareader', 'tempdb_db_datawriter') ";
 
 
 

--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -36,9 +36,9 @@ typedef enum {
 static babelfish_status bbf_status = NONE;
 
 static char default_bbf_roles[] = "('sysadmin', 'bbf_role_admin', 'securityadmin', "
-								  "'master_dbo', 'master_db_owner', 'master_guest', 'master_db_accessadmin', "
-								  "'msdb_dbo', 'msdb_db_owner', 'msdb_guest', 'msdb_db_accessadmin', "
-								  "'tempdb_dbo', 'tempdb_db_owner', 'tempdb_guest', 'tempdb_db_accessadmin')";
+								  "'master_dbo', 'master_db_owner', 'master_guest', 'master_db_accessadmin', 'master_db_datareader', 'master_db_datawriter', "
+								  "'msdb_dbo', 'msdb_db_owner', 'msdb_guest', 'msdb_db_accessadmin', 'msdb_db_datareader', 'msdb_db_datawriter', "
+								  "'tempdb_dbo', 'tempdb_db_owner', 'tempdb_guest', 'tempdb_db_accessadmin', 'tempdb_db_datareader', 'tempdb_db_datawriter')";
 
 /*
  * Run a query, return the results, exit program on failure.


### PR DESCRIPTION
### Description

We need to skip dumping these fixed roles db_datareader/db_datawriter for inbuilt databases like master, tempdb, msdb.

Extension PR: https://github.com/amazon-aurora/babelfish_extensions/pull/68

### Issues Resolved

Task: BABEL-3883
Signed-off-by: Shalini Lohia <lshalini@amazon.com>
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
