### PR TITLE
Support fixed database role db_ddladmin

### DIFF
--- a/.github/workflows/test_rpm.yml
+++ b/.github/workflows/test_rpm.yml
@@ -1,5 +1,5 @@
 name: BabelfishDump RPM Test
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build-rpm:

--- a/src/backend/catalog/pg_proc.c
+++ b/src/backend/catalog/pg_proc.c
@@ -125,6 +125,11 @@ ProcedureCreate(const char *procedureName,
 	 */
 	Assert(PointerIsValid(prosrc));
 
+	if (pltsql_get_object_owner_hook)
+	{
+		proowner = (*pltsql_get_object_owner_hook)(procNamespace, proowner);
+	}
+
 	parameterCount = parameterTypes->dim1;
 	if (parameterCount < 0 || parameterCount > FUNC_MAX_ARGS)
 		ereport(ERROR,

--- a/src/backend/catalog/pg_type.c
+++ b/src/backend/catalog/pg_type.c
@@ -254,6 +254,11 @@ TypeCreate(Oid newTypeOid,
 				 errmsg("invalid type internal size %d",
 						internalSize)));
 
+	if (pltsql_get_object_owner_hook)
+	{
+		ownerId = (*pltsql_get_object_owner_hook)(typeNamespace, ownerId);
+	}
+
 	if (passedByValue)
 	{
 		/*

--- a/src/backend/commands/alter.c
+++ b/src/backend/commands/alter.c
@@ -223,7 +223,8 @@ AlterObjectRename_internal(Relation rel, Oid objectId, const char *new_name)
 		Assert(!isnull);
 		ownerId = DatumGetObjectId(datum);
 
-		if (!has_privs_of_role(GetUserId(), DatumGetObjectId(ownerId)))
+		if (!has_privs_of_role(GetUserId(), DatumGetObjectId(ownerId)) &&
+			!(OidIsValid(namespaceId) && IS_BBF_DB_DDLADMIN(namespaceId)))
 			aclcheck_error(ACLCHECK_NOT_OWNER, get_object_type(classId, objectId),
 						   old_name);
 

--- a/src/backend/commands/dropcmds.c
+++ b/src/backend/commands/dropcmds.c
@@ -112,6 +112,7 @@ RemoveObjects(DropStmt *stmt)
 		if ((!OidIsValid(namespaceId) ||
 			!object_ownercheck(NamespaceRelationId, namespaceId, GetUserId())) &&
 			!(OidIsValid(namespaceId) && IS_BBF_DB_DDLADMIN(namespaceId)) &&
+			!(stmt->removeType == OBJECT_SCHEMA && IS_BBF_DB_DDLADMIN(address.objectId)) &&
 			!(relation != NULL && IS_BBF_DB_DDLADMIN(RelationGetNamespace(relation))))
 			check_object_ownership(GetUserId(), stmt->removeType, address,
 								   object, relation);

--- a/src/backend/commands/dropcmds.c
+++ b/src/backend/commands/dropcmds.c
@@ -109,8 +109,9 @@ RemoveObjects(DropStmt *stmt)
 
 		/* Check permissions. */
 		namespaceId = get_object_namespace(&address);
-		if (!OidIsValid(namespaceId) ||
-			!object_ownercheck(NamespaceRelationId, namespaceId, GetUserId()))
+		if ((!OidIsValid(namespaceId) ||
+			!object_ownercheck(NamespaceRelationId, namespaceId, GetUserId())) &&
+			!IS_BBF_DB_DDLADMIN(namespaceId))
 			check_object_ownership(GetUserId(), stmt->removeType, address,
 								   object, relation);
 

--- a/src/backend/commands/dropcmds.c
+++ b/src/backend/commands/dropcmds.c
@@ -109,9 +109,10 @@ RemoveObjects(DropStmt *stmt)
 
 		/* Check permissions. */
 		namespaceId = get_object_namespace(&address);
-		if (!OidIsValid(namespaceId) ||
-			(!object_ownercheck(NamespaceRelationId, namespaceId, GetUserId()) &&
-			!IS_BBF_DB_DDLADMIN(namespaceId)))
+		if ((!OidIsValid(namespaceId) ||
+			!object_ownercheck(NamespaceRelationId, namespaceId, GetUserId())) &&
+			(!OidIsValid(namespaceId) || !IS_BBF_DB_DDLADMIN(namespaceId)) &&
+			(relation == NULL || !IS_BBF_DB_DDLADMIN(RelationGetNamespace(relation))))
 			check_object_ownership(GetUserId(), stmt->removeType, address,
 								   object, relation);
 

--- a/src/backend/commands/dropcmds.c
+++ b/src/backend/commands/dropcmds.c
@@ -111,8 +111,8 @@ RemoveObjects(DropStmt *stmt)
 		namespaceId = get_object_namespace(&address);
 		if ((!OidIsValid(namespaceId) ||
 			!object_ownercheck(NamespaceRelationId, namespaceId, GetUserId())) &&
-			(!OidIsValid(namespaceId) || !IS_BBF_DB_DDLADMIN(namespaceId)) &&
-			(relation == NULL || !IS_BBF_DB_DDLADMIN(RelationGetNamespace(relation))))
+			!(OidIsValid(namespaceId) && IS_BBF_DB_DDLADMIN(namespaceId)) &&
+			!(relation != NULL && IS_BBF_DB_DDLADMIN(RelationGetNamespace(relation))))
 			check_object_ownership(GetUserId(), stmt->removeType, address,
 								   object, relation);
 

--- a/src/backend/commands/dropcmds.c
+++ b/src/backend/commands/dropcmds.c
@@ -109,9 +109,9 @@ RemoveObjects(DropStmt *stmt)
 
 		/* Check permissions. */
 		namespaceId = get_object_namespace(&address);
-		if ((!OidIsValid(namespaceId) ||
-			!object_ownercheck(NamespaceRelationId, namespaceId, GetUserId())) &&
-			!IS_BBF_DB_DDLADMIN(namespaceId))
+		if (!OidIsValid(namespaceId) ||
+			(!object_ownercheck(NamespaceRelationId, namespaceId, GetUserId()) &&
+			!IS_BBF_DB_DDLADMIN(namespaceId)))
 			check_object_ownership(GetUserId(), stmt->removeType, address,
 								   object, relation);
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -826,6 +826,12 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("only shared relations can be placed in pg_global tablespace")));
 
+
+	if (pltsql_get_object_owner_hook && !OidIsValid(ownerId))
+	{
+		ownerId = (*pltsql_get_object_owner_hook)(namespaceId, ownerId);
+	}
+
 	/* Identify user ID that will own the table */
 	if (!OidIsValid(ownerId))
 		ownerId = GetUserId();
@@ -6465,7 +6471,7 @@ ATSimplePermissions(AlterTableType cmdtype, Relation rel, int allowed_targets)
 	}
 
 	/* Permissions checks */
-	if (!object_ownercheck(RelationRelationId, RelationGetRelid(rel), GetUserId()))
+	if (!object_ownercheck(RelationRelationId, RelationGetRelid(rel), GetUserId()) && !IS_BBF_DB_DDLADMIN(RelationRelationId, RelationGetNamespace(rel)))
 		aclcheck_error(ACLCHECK_NOT_OWNER, get_relkind_objtype(rel->rd_rel->relkind),
 					   RelationGetRelationName(rel));
 
@@ -17284,7 +17290,7 @@ RangeVarCallbackForAlterRelation(const RangeVar *rv, Oid relid, Oid oldrelid,
 	relkind = classform->relkind;
 
 	/* Must own relation. */
-	if (!object_ownercheck(RelationRelationId, relid, GetUserId()))
+	if (!object_ownercheck(RelationRelationId, relid, GetUserId()) && !IS_BBF_DB_DDLADMIN(RelationRelationId, classform->relnamespace))
 		aclcheck_error(ACLCHECK_NOT_OWNER, get_relkind_objtype(get_rel_relkind(relid)), rv->relname);
 
 	/* No system table modifications unless explicitly allowed. */

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -17255,7 +17255,7 @@ RangeVarCallbackOwnsRelation(const RangeVar *relation,
 	if (!HeapTupleIsValid(tuple))	/* should not happen */
 		elog(ERROR, "cache lookup failed for relation %u", relId);
 
-	if (!object_ownercheck(RelationRelationId, relId, GetUserId()))
+	if (!object_ownercheck(RelationRelationId, relId, GetUserId()) && !IS_BBF_DB_DDLADMIN(get_rel_namespace(relId)))
 		aclcheck_error(ACLCHECK_NOT_OWNER, get_relkind_objtype(get_rel_relkind(relId)),
 					   relation->relname);
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1630,7 +1630,8 @@ RangeVarCallbackForDropRelation(const RangeVar *rel, Oid relOid, Oid oldRelOid,
 
 	/* Allow DROP to either table owner or schema owner */
 	if (!object_ownercheck(RelationRelationId, relOid, GetUserId()) &&
-		!object_ownercheck(NamespaceRelationId, classform->relnamespace, GetUserId()))
+		!object_ownercheck(NamespaceRelationId, classform->relnamespace, GetUserId()) &&
+		!IS_BBF_DB_DDLADMIN(classform->relnamespace))
 		aclcheck_error(ACLCHECK_NOT_OWNER,
 					   get_relkind_objtype(classform->relkind),
 					   rel->relname);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -3591,7 +3591,8 @@ renameatt_check(Oid myrelid, Form_pg_class classform, bool recursing)
 	/*
 	 * permissions checking.  only the owner of a class can change its schema.
 	 */
-	if (!object_ownercheck(RelationRelationId, myrelid, GetUserId()))
+	if (!object_ownercheck(RelationRelationId, myrelid, GetUserId()) &&
+		!IS_BBF_DB_DDLADMIN(get_rel_namespace(myrelid)))
 		aclcheck_error(ACLCHECK_NOT_OWNER, get_relkind_objtype(get_rel_relkind(myrelid)),
 					   NameStr(classform->relname));
 	if (!allowSystemTableMods && IsSystemClass(myrelid, classform))

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6471,7 +6471,7 @@ ATSimplePermissions(AlterTableType cmdtype, Relation rel, int allowed_targets)
 	}
 
 	/* Permissions checks */
-	if (!object_ownercheck(RelationRelationId, RelationGetRelid(rel), GetUserId()) && !IS_BBF_DB_DDLADMIN(RelationRelationId, RelationGetNamespace(rel)))
+	if (!object_ownercheck(RelationRelationId, RelationGetRelid(rel), GetUserId()) && !IS_BBF_DB_DDLADMIN(RelationGetNamespace(rel)))
 		aclcheck_error(ACLCHECK_NOT_OWNER, get_relkind_objtype(rel->rd_rel->relkind),
 					   RelationGetRelationName(rel));
 
@@ -17290,7 +17290,7 @@ RangeVarCallbackForAlterRelation(const RangeVar *rv, Oid relid, Oid oldrelid,
 	relkind = classform->relkind;
 
 	/* Must own relation. */
-	if (!object_ownercheck(RelationRelationId, relid, GetUserId()) && !IS_BBF_DB_DDLADMIN(RelationRelationId, classform->relnamespace))
+	if (!object_ownercheck(RelationRelationId, relid, GetUserId()) && !IS_BBF_DB_DDLADMIN(classform->relnamespace))
 		aclcheck_error(ACLCHECK_NOT_OWNER, get_relkind_objtype(get_rel_relkind(relid)), rv->relname);
 
 	/* No system table modifications unless explicitly allowed. */

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -2591,7 +2591,8 @@ MergeAttributes(List *schema, List *supers, char relpersistence,
 		 * We should have an UNDER permission flag for this, but for now,
 		 * demand that creator of a child table own the parent.
 		 */
-		if (!object_ownercheck(RelationRelationId, RelationGetRelid(relation), GetUserId()))
+		if (!object_ownercheck(RelationRelationId, RelationGetRelid(relation), GetUserId()) &&
+			!IS_BBF_DB_DDLADMIN(RelationGetNamespace(relation)))
 			aclcheck_error(ACLCHECK_NOT_OWNER, get_relkind_objtype(relation->rd_rel->relkind),
 						   RelationGetRelationName(relation));
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6473,7 +6473,8 @@ ATSimplePermissions(AlterTableType cmdtype, Relation rel, int allowed_targets)
 	}
 
 	/* Permissions checks */
-	if (!object_ownercheck(RelationRelationId, RelationGetRelid(rel), GetUserId()) && !IS_BBF_DB_DDLADMIN(RelationGetNamespace(rel)))
+	if (!object_ownercheck(RelationRelationId, RelationGetRelid(rel), GetUserId()) &&
+		!IS_BBF_DB_DDLADMIN(RelationGetNamespace(rel)))
 		aclcheck_error(ACLCHECK_NOT_OWNER, get_relkind_objtype(rel->rd_rel->relkind),
 					   RelationGetRelationName(rel));
 
@@ -17256,7 +17257,8 @@ RangeVarCallbackOwnsRelation(const RangeVar *relation,
 	if (!HeapTupleIsValid(tuple))	/* should not happen */
 		elog(ERROR, "cache lookup failed for relation %u", relId);
 
-	if (!object_ownercheck(RelationRelationId, relId, GetUserId()) && !IS_BBF_DB_DDLADMIN(get_rel_namespace(relId)))
+	if (!object_ownercheck(RelationRelationId, relId, GetUserId()) &&
+		!IS_BBF_DB_DDLADMIN(get_rel_namespace(relId)))
 		aclcheck_error(ACLCHECK_NOT_OWNER, get_relkind_objtype(get_rel_relkind(relId)),
 					   relation->relname);
 
@@ -17292,7 +17294,8 @@ RangeVarCallbackForAlterRelation(const RangeVar *rv, Oid relid, Oid oldrelid,
 	relkind = classform->relkind;
 
 	/* Must own relation. */
-	if (!object_ownercheck(RelationRelationId, relid, GetUserId()) && !IS_BBF_DB_DDLADMIN(classform->relnamespace))
+	if (!object_ownercheck(RelationRelationId, relid, GetUserId()) &&
+		!IS_BBF_DB_DDLADMIN(classform->relnamespace))
 		aclcheck_error(ACLCHECK_NOT_OWNER, get_relkind_objtype(get_rel_relkind(relid)), rv->relname);
 
 	/* No system table modifications unless explicitly allowed. */

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -11771,7 +11771,7 @@ checkFkeyPermissions(Relation rel, int16 *attnums, int natts)
 	/* Okay if we have relation-level REFERENCES permission */
 	aclresult = pg_class_aclcheck(RelationGetRelid(rel), roleid,
 								  ACL_REFERENCES);
-	if (aclresult == ACLCHECK_OK)
+	if (aclresult == ACLCHECK_OK || IS_BBF_DB_DDLADMIN(RelationGetNamespace(rel)))
 		return;
 	/* Else we must have REFERENCES on each column */
 	for (i = 0; i < natts; i++)

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -1576,7 +1576,8 @@ RangeVarCallbackForRenameTrigger(const RangeVar *rv, Oid relid, Oid oldrelid,
 				 errdetail_relkind_not_supported(form->relkind)));
 
 	/* you must own the table to rename one of its triggers */
-	if (!object_ownercheck(RelationRelationId, relid, GetUserId()) && !IS_BBF_DB_DDLADMIN(get_rel_namespace(relid)))
+	if (!object_ownercheck(RelationRelationId, relid, GetUserId()) &&
+		!IS_BBF_DB_DDLADMIN(get_rel_namespace(relid)))
 		aclcheck_error(ACLCHECK_NOT_OWNER, get_relkind_objtype(get_rel_relkind(relid)), rv->relname);
 	if (!allowSystemTableMods && IsSystemClass(relid, form))
 		ereport(ERROR,

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -383,7 +383,7 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 	{
 		aclresult = pg_class_aclcheck(RelationGetRelid(rel), GetUserId(),
 									  ACL_TRIGGER);
-		if (aclresult != ACLCHECK_OK)
+		if (aclresult != ACLCHECK_OK && !IS_BBF_DB_DDLADMIN(RelationGetNamespace(rel)))
 			aclcheck_error(aclresult, get_relkind_objtype(rel->rd_rel->relkind),
 						   RelationGetRelationName(rel));
 
@@ -758,7 +758,7 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 	if (!isInternal)
 	{
 		aclresult = object_aclcheck(ProcedureRelationId, funcoid, GetUserId(), ACL_EXECUTE);
-		if (aclresult != ACLCHECK_OK)
+		if (aclresult != ACLCHECK_OK && !IS_BBF_DB_DDLADMIN(RelationGetNamespace(rel)))
 			aclcheck_error(aclresult, OBJECT_FUNCTION,
 						   NameListToString(stmt->funcname));
 	}

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -758,7 +758,7 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 	if (!isInternal)
 	{
 		aclresult = object_aclcheck(ProcedureRelationId, funcoid, GetUserId(), ACL_EXECUTE);
-		if (aclresult != ACLCHECK_OK && !IS_BBF_DB_DDLADMIN(RelationGetNamespace(rel)))
+		if (aclresult != ACLCHECK_OK && !IS_BBF_DB_DDLADMIN(get_func_namespace(funcoid)))
 			aclcheck_error(aclresult, OBJECT_FUNCTION,
 						   NameListToString(stmt->funcname));
 	}

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -1576,7 +1576,7 @@ RangeVarCallbackForRenameTrigger(const RangeVar *rv, Oid relid, Oid oldrelid,
 				 errdetail_relkind_not_supported(form->relkind)));
 
 	/* you must own the table to rename one of its triggers */
-	if (!object_ownercheck(RelationRelationId, relid, GetUserId()))
+	if (!object_ownercheck(RelationRelationId, relid, GetUserId()) && !IS_BBF_DB_DDLADMIN(get_rel_namespace(relid)))
 		aclcheck_error(ACLCHECK_NOT_OWNER, get_relkind_objtype(get_rel_relkind(relid)), rv->relname);
 	if (!allowSystemTableMods && IsSystemClass(relid, form))
 		ereport(ERROR,

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -3637,7 +3637,8 @@ RenameType(RenameStmt *stmt)
 	typTup = (Form_pg_type) GETSTRUCT(tup);
 
 	/* check permissions on type */
-	if (!object_ownercheck(TypeRelationId, typeOid, GetUserId()))
+	if (!object_ownercheck(TypeRelationId, typeOid, GetUserId()) &&
+		!IS_BBF_DB_DDLADMIN(typTup->typnamespace))
 		aclcheck_error_type(ACLCHECK_NOT_OWNER, typeOid);
 
 	/* ALTER DOMAIN used on a non-domain? */

--- a/src/backend/rewrite/rewriteDefine.c
+++ b/src/backend/rewrite/rewriteDefine.c
@@ -278,7 +278,7 @@ DefineQueryRewrite(const char *rulename,
 	/*
 	 * Check user has permission to apply rules to this relation.
 	 */
-	if (!object_ownercheck(RelationRelationId, event_relid, GetUserId()))
+	if (!object_ownercheck(RelationRelationId, event_relid, GetUserId()) && !IS_BBF_DB_DDLADMIN(RelationGetNamespace(event_relation)))
 		aclcheck_error(ACLCHECK_NOT_OWNER, get_relkind_objtype(event_relation->rd_rel->relkind),
 					   RelationGetRelationName(event_relation));
 

--- a/src/backend/rewrite/rewriteDefine.c
+++ b/src/backend/rewrite/rewriteDefine.c
@@ -278,7 +278,8 @@ DefineQueryRewrite(const char *rulename,
 	/*
 	 * Check user has permission to apply rules to this relation.
 	 */
-	if (!object_ownercheck(RelationRelationId, event_relid, GetUserId()) && !IS_BBF_DB_DDLADMIN(RelationGetNamespace(event_relation)))
+	if (!object_ownercheck(RelationRelationId, event_relid, GetUserId()) &&
+		!IS_BBF_DB_DDLADMIN(RelationGetNamespace(event_relation)))
 		aclcheck_error(ACLCHECK_NOT_OWNER, get_relkind_objtype(event_relation->rd_rel->relkind),
 					   RelationGetRelationName(event_relation));
 

--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -126,6 +126,8 @@ static void RoleMembershipCacheCallback(Datum arg, int cacheid, uint32 hashvalue
 
 bbf_get_sysadmin_oid_hook_type bbf_get_sysadmin_oid_hook = NULL;
 get_bbf_admin_oid_hook_type get_bbf_admin_oid_hook = NULL;
+pltsql_get_object_owner_hook_type pltsql_get_object_owner_hook = NULL;
+is_bbf_db_ddladmin_operation_hook_type is_bbf_db_ddladmin_operation_hook = NULL;
 
 
 /*

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -55,13 +55,13 @@ static babelfish_status bbf_status = NONE;
 static char *default_bbf_db_principals =
 			"('master_dbo', 'master_db_owner', 'master_guest', "
 			"'master_db_accessadmin', 'master_db_securityadmin', "
-			"'master_db_datareader', 'master_db_datawriter', "
+			"'master_db_datareader', 'master_db_datawriter', 'master_db_ddladmin', "
 			"'msdb_dbo', 'msdb_db_owner', 'msdb_guest', "
 			"'msdb_db_accessadmin', 'msdb_db_securityadmin', "
-			"'msdb_db_datareader', 'msdb_db_datawriter', "
+			"'msdb_db_datareader', 'msdb_db_datawriter', 'msdb_db_ddladmin', "
 			"'tempdb_dbo', 'tempdb_db_owner', 'tempdb_guest', "
 			"'tempdb_db_accessadmin', 'tempdb_db_securityadmin', "
-			"'tempdb_db_datareader', 'tempdb_db_datawriter')" ;
+			"'tempdb_db_datareader', 'tempdb_db_datawriter', 'tempdb_db_ddladmin')";
 
 
 
@@ -2002,7 +2002,7 @@ dumpBabelPhysicalDatabaseACLs(Archive *fout)
 					"\n	SET LOCAL ROLE sysadmin;"
 					"\n	FOR rolname, original_name IN ("
 					"\n		SELECT a.rolname, a.orig_username FROM sys.babelfish_authid_user_ext a"
-					"\n			WHERE orig_username IN ('dbo','db_accessadmin','db_securityadmin') AND"
+					"\n			WHERE orig_username IN ('dbo','db_accessadmin','db_securityadmin','db_ddladmin') AND"
 					"\n			database_name NOT IN ('master', 'tempdb', 'msdb')");
 
 	if (bbf_db_name)
@@ -2013,7 +2013,7 @@ dumpBabelPhysicalDatabaseACLs(Archive *fout)
 					"\n	) LOOP"
 					"\n		CASE WHEN original_name = 'dbo' THEN"
 					"\n			EXECUTE format('GRANT CREATE, CONNECT, TEMPORARY ON DATABASE \"%%s\" TO \"%%s\"; ', CURRENT_DATABASE(), rolname);"
-					"\n		WHEN original_name IN ('db_securityadmin','db_accessadmin') THEN"
+					"\n		WHEN original_name IN ('db_securityadmin','db_accessadmin','db_ddladmin') THEN"
 					"\n			EXECUTE format('GRANT CREATE ON DATABASE \"%%s\" TO \"%%s\"; ', CURRENT_DATABASE(), rolname);"
 					"\n		END CASE;"
 					"\n	END LOOP;"

--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -37,14 +37,14 @@ static babelfish_status bbf_status = NONE;
 
 static char default_bbf_roles[] = "('sysadmin', 'bbf_role_admin', 'securityadmin', 'dbcreator', "
                                   "'master_dbo', 'master_db_owner', 'master_guest', "
-                                  "'master_db_accessadmin', 'master_db_securityadmin', "
+                                  "'master_db_accessadmin', 'master_db_securityadmin', 'master_db_ddladmin', "
                                   "'master_db_datareader', 'master_db_datawriter', "
                                   "'msdb_dbo', 'msdb_db_owner', 'msdb_guest', "
                                   "'msdb_db_accessadmin', 'msdb_db_securityadmin', "
-                                  "'msdb_db_datareader', 'msdb_db_datawriter', "
+                                  "'msdb_db_datareader', 'msdb_db_datawriter', 'msdb_db_ddladmin', "
                                   "'tempdb_dbo', 'tempdb_db_owner', 'tempdb_guest', "
                                   "'tempdb_db_accessadmin', 'tempdb_db_securityadmin', "
-                                  "'tempdb_db_datareader', 'tempdb_db_datawriter')" ;
+                                  "'tempdb_db_datareader', 'tempdb_db_datawriter', 'tempdb_db_ddladmin')";
 
 /*
  * Run a query, return the results, exit program on failure.

--- a/src/include/utils/acl.h
+++ b/src/include/utils/acl.h
@@ -291,12 +291,12 @@ extern PGDLLEXPORT bbf_execute_grantstmt_as_dbsecadmin_hook_type bbf_execute_gra
 typedef Oid (*pltsql_get_object_owner_hook_type) (Oid, Oid);
 extern PGDLLEXPORT pltsql_get_object_owner_hook_type pltsql_get_object_owner_hook;
 
-typedef bool (*is_bbf_db_ddladmin_operation_hook_type) (Oid classId,Oid namespaceId);
+typedef bool (*is_bbf_db_ddladmin_operation_hook_type) (Oid namespaceId);
 extern PGDLLEXPORT is_bbf_db_ddladmin_operation_hook_type is_bbf_db_ddladmin_operation_hook;
 
-#define IS_BBF_DB_DDLADMIN(classId, namespaceId) \
+#define IS_BBF_DB_DDLADMIN(namespaceId) \
 	(is_bbf_db_ddladmin_operation_hook &&       \
-	 is_bbf_db_ddladmin_operation_hook(classId, namespaceId))
+	 is_bbf_db_ddladmin_operation_hook(namespaceId))
 
 
 #endif							/* ACL_H */

--- a/src/include/utils/acl.h
+++ b/src/include/utils/acl.h
@@ -288,4 +288,15 @@ extern PGDLLEXPORT get_bbf_admin_oid_hook_type get_bbf_admin_oid_hook;
 typedef void (*bbf_execute_grantstmt_as_dbsecadmin_hook_type) (ObjectType objType, Oid objId, Oid ownerId, AclMode privileges, Oid *grantorId, AclMode *grantOptions);
 extern PGDLLEXPORT bbf_execute_grantstmt_as_dbsecadmin_hook_type bbf_execute_grantstmt_as_dbsecadmin_hook;
 
+typedef Oid (*pltsql_get_object_owner_hook_type) (Oid, Oid);
+extern PGDLLEXPORT pltsql_get_object_owner_hook_type pltsql_get_object_owner_hook;
+
+typedef bool (*is_bbf_db_ddladmin_operation_hook_type) (Oid classId,Oid namespaceId);
+extern PGDLLEXPORT is_bbf_db_ddladmin_operation_hook_type is_bbf_db_ddladmin_operation_hook;
+
+#define IS_BBF_DB_DDLADMIN(classId, namespaceId) \
+	(is_bbf_db_ddladmin_operation_hook &&       \
+	 is_bbf_db_ddladmin_operation_hook(classId, namespaceId))
+
+
 #endif							/* ACL_H */


### PR DESCRIPTION
### Description

Engine changes for babelfish fixed database role db_ddladmin.
1. Implement hook to allow members of db_ddladmin to ALTER/DROP on database objects.
2. Handle dump restore changes.

#### Extensions PR : https://github.com/amazon-aurora/babelfish_extensions/pull/71/
#### Engine PR : https://github.com/amazon-aurora/postgresql_modified_for_babelfish/pull/101/

### Issues Resolved

[BABEL-5116]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).