### PR TITLE
Refactor ListenSocket array.

### DIFF
--- a/src/backend/libpq/pqcomm.c
+++ b/src/backend/libpq/pqcomm.c
@@ -318,16 +318,17 @@ socket_close(int code, Datum arg)
  * specified.  For TCP ports, hostName is either NULL for all interfaces or
  * the interface to listen on, and unixSocketDir is ignored (can be NULL).
  *
- * Successfully opened sockets are added to the ListenSocket[] array (of
- * length MaxListen), at the first position that isn't PGINVALID_SOCKET.
+ * Successfully opened sockets are appended to the ListenSockets[] array.  On
+ * entry, *NumListenSockets holds the number of elements currently in the
+ * array, and it is updated to reflect the opened sockets.  MaxListen is the
+ * allocated size of the array.
  *
  * RETURNS: STATUS_OK or STATUS_ERROR
  */
-
 int
 StreamServerPort(int family, const char *hostName, unsigned short portNumber,
 				 const char *unixSocketDir,
-				 pgsocket ListenSocket[], int MaxListen)
+				 pgsocket ListenSockets[], int *NumListenSockets, int MaxListen)
 {
 	pgsocket	fd;
 	int			err;

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -1618,8 +1618,7 @@ CloseServerPorts(int status, Datum arg)
 	 * condition if a new postmaster wants to re-use the TCP port number.
 	 */
 	for (i = 0; i < NumListenSockets; i++) {
-		if ((ListenConfig[i]->fn_close)(ListenSockets[i]) != 0)
-			elog(LOG, "could not close listen socket: %m");
+		(ListenConfig[i]->fn_close)(ListenSockets[i]);
 		ListenConfig[i] = NULL;
 	}
 	NumListenSockets = 0;
@@ -2730,9 +2729,7 @@ ClosePostmasterPorts(bool am_syslogger)
 	{
 		for (int i = 0; i < NumListenSockets; i++) 
 		{
-			if ((ListenConfig[i]->fn_close)(ListenSockets[i]) != 0)
-				elog(LOG, "could not close listen socket: %m");
-
+			(ListenConfig[i]->fn_close)(ListenSockets[i]);
 			ListenConfig[i] = NULL;
 		}
 		pfree(ListenSockets);

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -231,7 +231,8 @@ listen_init_hook_type	listen_init_hook = NULL;
 
 /* The socket(s) we're listening to. */
 #define MAXLISTEN	64
-static pgsocket ListenSocket[MAXLISTEN];
+static int	NumListenSockets = 0;
+static pgsocket *ListenSockets = NULL;
 
 /* The wire protocol callbacks to use for those server sockets. */
 static ProtocolExtensionConfig *ListenConfig[MAXLISTEN];
@@ -614,7 +615,6 @@ PostmasterMain(int argc, char *argv[])
 	int			status;
 	char	   *userDoption = NULL;
 	bool		listen_addr_saved = false;
-	int			i;
 	char	   *output_config_variable = NULL;
 
 	InitProcessGlobals();
@@ -1169,17 +1169,6 @@ PostmasterMain(int argc, char *argv[])
 						LOG_METAINFO_DATAFILE)));
 
 	/*
-	 * Initialize input sockets.
-	 *
-	 * Mark them all closed, and set up an on_proc_exit function that's
-	 * charged with closing the sockets again at postmaster shutdown.
-	 */
-	for (i = 0; i < MAXLISTEN; i++)
-		ListenSocket[i] = PGINVALID_SOCKET;
-
-	on_proc_exit(CloseServerPorts, 0);
-
-	/*
 	 * If enabled, start up syslogger collection subprocess
 	 */
 	SysLoggerPID = SysLogger_Start();
@@ -1213,7 +1202,13 @@ PostmasterMain(int argc, char *argv[])
 
 	/*
 	 * Establish input sockets.
+	 *
+	 * First set up an on_proc_exit function that's charged with closing the
+	 * sockets again at postmaster shutdown.
 	 */
+	ListenSockets = palloc(MAXLISTEN * sizeof(pgsocket));
+	on_proc_exit(CloseServerPorts, 0);
+
 	if (ListenAddresses)
 	{
 		char	   *rawstring;
@@ -1242,12 +1237,16 @@ PostmasterMain(int argc, char *argv[])
 				status = StreamServerPort(AF_UNSPEC, NULL,
 										  (unsigned short) PostPortNumber,
 										  NULL,
-										  ListenSocket, MAXLISTEN);
+										  ListenSockets,
+										  &NumListenSockets,
+										  MAXLISTEN);
 			else
 				status = StreamServerPort(AF_UNSPEC, curhost,
 										  (unsigned short) PostPortNumber,
 										  NULL,
-										  ListenSocket, MAXLISTEN);
+										  ListenSockets,
+										  &NumListenSockets,
+										  MAXLISTEN);
 
 			if (status == STATUS_OK)
 			{
@@ -1275,7 +1274,7 @@ PostmasterMain(int argc, char *argv[])
 
 #ifdef USE_BONJOUR
 	/* Register for Bonjour only if we opened TCP socket(s) */
-	if (enable_bonjour && ListenSocket[0] != PGINVALID_SOCKET)
+	if (enable_bonjour && NumListenSockets > 0)
 	{
 		DNSServiceErrorType err;
 
@@ -1339,7 +1338,9 @@ PostmasterMain(int argc, char *argv[])
 			status = StreamServerPort(AF_UNIX, NULL,
 									  (unsigned short) PostPortNumber,
 									  socketdir,
-									  ListenSocket, MAXLISTEN);
+									  ListenSockets,
+									  &NumListenSockets,
+									  MAXLISTEN);
 
 			if (status == STATUS_OK)
 			{
@@ -1372,7 +1373,7 @@ PostmasterMain(int argc, char *argv[])
 	/*
 	 * check that we have some socket to listen on
 	 */
-	if (ListenSocket[0] == PGINVALID_SOCKET)
+	if (NumListenSockets == 0)
 		ereport(FATAL,
 				(errmsg("no socket created for listening")));
 
@@ -1616,15 +1617,12 @@ CloseServerPorts(int status, Datum arg)
 	 * before we remove the postmaster.pid lockfile; otherwise there's a race
 	 * condition if a new postmaster wants to re-use the TCP port number.
 	 */
-	for (i = 0; i < MAXLISTEN; i++)
-	{
-		if (ListenSocket[i] != PGINVALID_SOCKET)
-		{
-			(ListenConfig[i]->fn_close)(ListenSocket[i]);
-			ListenSocket[i] = PGINVALID_SOCKET;
-			ListenConfig[i] = NULL;
-		}
+	for (i = 0; i < NumListenSockets; i++) {
+		if ((ListenConfig[i]->fn_close)(ListenSockets[i]) != 0)
+			elog(LOG, "could not close listen socket: %m");
+		ListenConfig[i] = NULL;
 	}
+	NumListenSockets = 0;
 
 	/*
 	 * Next, remove any filesystem entries for Unix sockets.  To avoid race
@@ -1705,42 +1703,29 @@ getInstallationPaths(const char *argv0)
 int
 listen_have_free_slot(void)
 {
-	int	listen_index = 0;
+	if (NumListenSockets == MAXLISTEN) {
+		ereport(LOG,
+				(errmsg("could not bind to all requested addresses: MAXLISTEN (%d) exceeded",
+						MAXLISTEN)));
 
-	/* See if there is still room to add 1 more socket. */
-	for (; listen_index < MAXLISTEN; listen_index++)
-	{
-		if (ListenSocket[listen_index] == PGINVALID_SOCKET)
-			return true;
+		return false;
 	}
 
-	ereport(LOG,
-			(errmsg("could not bind to all requested addresses: MAXLISTEN (%d) exceeded",
-					MAXLISTEN)));
-
-	return false;
+	return true;
 }
 
 void
 listen_add_socket(pgsocket fd, ProtocolExtensionConfig *protocol_config)
 {
-	int	listen_index = 0;
-
-	/* Lookup the next free slot */
-	for (; listen_index < MAXLISTEN; listen_index++)
-	{
-		if (ListenSocket[listen_index] == PGINVALID_SOCKET)
-			break;
-	}
-
 	/* Caller must have checked with listen_have_free_slot() before */
-	Assert(listen_index < MAXLISTEN);
+	Assert(NumListenSockets < MAXLISTEN);
 
 	if (protocol_config == NULL)
 		protocol_config = &default_protocol_config;
 
-	ListenSocket[listen_index] = fd;
-	ListenConfig[listen_index] = protocol_config;
+	ListenSockets[NumListenSockets] = fd;
+	ListenConfig[NumListenSockets] = protocol_config;
+	(NumListenSockets)++;
 }
 
 /*
@@ -1866,30 +1851,20 @@ DetermineSleepTime(void)
 static void
 ConfigurePostmasterWaitSet(bool accept_connections)
 {
-	int			nsockets;
-
 	if (pm_wait_set)
 		FreeWaitEventSet(pm_wait_set);
 	pm_wait_set = NULL;
 
-	/* How many server sockets do we need to wait for? */
-	nsockets = 0;
-	if (accept_connections)
-	{
-		while (nsockets < MAXLISTEN &&
-			   ListenSocket[nsockets] != PGINVALID_SOCKET)
-			++nsockets;
-	}
-
-	pm_wait_set = CreateWaitEventSet(CurrentMemoryContext, 1 + nsockets);
+	pm_wait_set = CreateWaitEventSet(CurrentMemoryContext,
+									 accept_connections ? (1 + NumListenSockets) : 1);
 	AddWaitEventToSet(pm_wait_set, WL_LATCH_SET, PGINVALID_SOCKET, MyLatch,
 					  NULL);
 
 	if (accept_connections)
 	{
-		for (int i = 0; i < nsockets; i++)
-			AddWaitEventToSet(pm_wait_set, WL_SOCKET_ACCEPT, ListenSocket[i],
-							  NULL, ListenConfig[i]);
+		for (int i = 0; i < NumListenSockets; i++)
+			AddWaitEventToSet(pm_wait_set, WL_SOCKET_ACCEPT, ListenSockets[i],
+							  NULL, NULL);
 	}
 }
 
@@ -2751,15 +2726,19 @@ ClosePostmasterPorts(bool am_syslogger)
 	 * EXEC_BACKEND mode.
 	 */
 #ifndef EXEC_BACKEND
-	for (int i = 0; i < MAXLISTEN; i++)
+	if (ListenSockets)
 	{
-		if (ListenSocket[i] != PGINVALID_SOCKET && ListenConfig[i] != NULL)
+		for (int i = 0; i < NumListenSockets; i++) 
 		{
-			(ListenConfig[i]->fn_close)(ListenSocket[i]);
-			ListenSocket[i] = PGINVALID_SOCKET;
+			if ((ListenConfig[i]->fn_close)(ListenSockets[i]) != 0)
+				elog(LOG, "could not close listen socket: %m");
+
 			ListenConfig[i] = NULL;
 		}
+		pfree(ListenSockets);
 	}
+	NumListenSockets = 0;
+	ListenSockets = NULL;
 #endif
 
 	/*

--- a/src/include/libpq/libpq.h
+++ b/src/include/libpq/libpq.h
@@ -66,7 +66,7 @@ extern PGDLLIMPORT WaitEventSet *FeBeWaitSet;
 
 extern int	StreamServerPort(int family, const char *hostName,
 							 unsigned short portNumber, const char *unixSocketDir,
-							 pgsocket ListenSocket[], int MaxListen);
+							 pgsocket ListenSocket[], int *NumListenSockets, int MaxListen);
 extern int	StreamConnection(pgsocket server_fd, Port *port);
 extern void StreamClose(pgsocket sock);
 extern void TouchSocketFiles(void);


### PR DESCRIPTION
Keep track of the used size of the array. That avoids looping through the whole array in a few places. It doesn't matter from a performance point of view since the array is small anyway, but this feels less surprising and is a little less code. Now that we have an explicit NumListenSockets variable that is statically initialized to 0, we don't need the loop to initialize the array.

Allocate the array in PostmasterContext. The array isn't needed in child processes, so this allows reusing that memory. We could easily make the array resizable now, but we haven't heard any complaints about the current 64 sockets limit.

Discussion: https://www.postgresql.org/message-id/7bb7ad65-a018-2419-742f-fa5fd877d338@iki.fi (cherry picked from commit e29c46439511a2ba8b447079f2308384a4228c92)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
