### PR TITLE
Fix crash on syslogger startup

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -2726,12 +2726,15 @@ ClosePostmasterPorts(bool am_syslogger)
 	 * EXEC_BACKEND mode.
 	 */
 #ifndef EXEC_BACKEND
-	for (int i = 0; i < NumListenSockets; i++) {
-		(ListenConfig[i]->fn_close)(ListenSockets[i]);
-		ListenConfig[i] = NULL;
+	if (ListenSockets)
+	{
+		for (int i = 0; i < NumListenSockets; i++) {
+			(ListenConfig[i]->fn_close)(ListenSockets[i]);
+			ListenConfig[i] = NULL;
+		}
+		pfree(ListenSockets);
 	}
 	NumListenSockets = 0;
-	pfree(ListenSockets);
 	ListenSockets = NULL;
 #endif
 


### PR DESCRIPTION
When syslogger starts up, ListenSockets is still NULL. Don't try to pfree it. Oversight in commit e29c464395.

Reported-by: Michael Paquier
Discussion: https://www.postgresql.org/message-id/ZR-uNkgL7m60lWUe@paquier.xyz (cherry picked from commit 5da0a622e88907722ce456d30dbf0565ed7a222b)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
