### PR TITLE
Rename ShmemVariableCache to TransamVariables

### DIFF
--- a/contrib/amcheck/verify_heapam.c
+++ b/contrib/amcheck/verify_heapam.c
@@ -81,12 +81,12 @@ typedef struct ToastedAttribute
 typedef struct HeapCheckContext
 {
 	/*
-	 * Cached copies of values from ShmemVariableCache and computed values
-	 * from them.
+	 * Cached copies of values from TransamVariables and computed values from
+	 * them.
 	 */
-	FullTransactionId next_fxid;	/* ShmemVariableCache->nextXid */
+	FullTransactionId next_fxid;	/* TransamVariables->nextXid */
 	TransactionId next_xid;		/* 32-bit version of next_fxid */
-	TransactionId oldest_xid;	/* ShmemVariableCache->oldestXid */
+	TransactionId oldest_xid;	/* TransamVariables->oldestXid */
 	FullTransactionId oldest_fxid;	/* 64-bit version of oldest_xid, computed
 									 * relative to next_fxid */
 	TransactionId safe_xmin;	/* this XID and newer ones can't become
@@ -1924,8 +1924,8 @@ update_cached_xid_range(HeapCheckContext *ctx)
 {
 	/* Make cached copies */
 	LWLockAcquire(XidGenLock, LW_SHARED);
-	ctx->next_fxid = ShmemVariableCache->nextXid;
-	ctx->oldest_xid = ShmemVariableCache->oldestXid;
+	ctx->next_fxid = TransamVariables->nextXid;
+	ctx->oldest_xid = TransamVariables->oldestXid;
 	LWLockRelease(XidGenLock);
 
 	/* And compute alternate versions of the same */
@@ -2062,7 +2062,7 @@ get_xid_status(TransactionId xid, HeapCheckContext *ctx,
 	*status = XID_COMMITTED;
 	LWLockAcquire(XactTruncationLock, LW_SHARED);
 	clog_horizon =
-		FullTransactionIdFromXidAndCtx(ShmemVariableCache->oldestClogXid,
+		FullTransactionIdFromXidAndCtx(TransamVariables->oldestClogXid,
 									   ctx);
 	if (FullTransactionIdPrecedesOrEquals(clog_horizon, fxid))
 	{

--- a/src/backend/access/transam/clog.c
+++ b/src/backend/access/transam/clog.c
@@ -758,12 +758,12 @@ ZeroCLOGPage(int64 pageno, bool writeXlog)
 
 /*
  * This must be called ONCE during postmaster or standalone-backend startup,
- * after StartupXLOG has initialized ShmemVariableCache->nextXid.
+ * after StartupXLOG has initialized TransamVariables->nextXid.
  */
 void
 StartupCLOG(void)
 {
-	TransactionId xid = XidFromFullTransactionId(ShmemVariableCache->nextXid);
+	TransactionId xid = XidFromFullTransactionId(TransamVariables->nextXid);
 	int64		pageno = TransactionIdToPage(xid);
 
 	LWLockAcquire(XactSLRULock, LW_EXCLUSIVE);
@@ -782,7 +782,7 @@ StartupCLOG(void)
 void
 TrimCLOG(void)
 {
-	TransactionId xid = XidFromFullTransactionId(ShmemVariableCache->nextXid);
+	TransactionId xid = XidFromFullTransactionId(TransamVariables->nextXid);
 	int64		pageno = TransactionIdToPage(xid);
 
 	LWLockAcquire(XactSLRULock, LW_EXCLUSIVE);

--- a/src/backend/access/transam/subtrans.c
+++ b/src/backend/access/transam/subtrans.c
@@ -250,7 +250,7 @@ ZeroSUBTRANSPage(int64 pageno)
 
 /*
  * This must be called ONCE during postmaster or standalone-backend startup,
- * after StartupXLOG has initialized ShmemVariableCache->nextXid.
+ * after StartupXLOG has initialized TransamVariables->nextXid.
  *
  * oldestActiveXID is the oldest XID of any prepared transaction, or nextXid
  * if there are none.
@@ -271,7 +271,7 @@ StartupSUBTRANS(TransactionId oldestActiveXID)
 	LWLockAcquire(SubtransSLRULock, LW_EXCLUSIVE);
 
 	startPage = TransactionIdToPage(oldestActiveXID);
-	nextXid = ShmemVariableCache->nextXid;
+	nextXid = TransamVariables->nextXid;
 	endPage = TransactionIdToPage(XidFromFullTransactionId(nextXid));
 
 	while (startPage != endPage)

--- a/src/backend/access/transam/twophase.c
+++ b/src/backend/access/transam/twophase.c
@@ -958,7 +958,7 @@ AdjustToFullTransactionId(TransactionId xid)
 	Assert(TransactionIdIsValid(xid));
 
 	LWLockAcquire(XidGenLock, LW_SHARED);
-	nextFullXid = ShmemVariableCache->nextXid;
+	nextFullXid = TransamVariables->nextXid;
 	LWLockRelease(XidGenLock);
 
 	nextXid = XidFromFullTransactionId(nextFullXid);
@@ -1948,7 +1948,7 @@ restoreTwoPhaseData(void)
  *
  * Scan the shared memory entries of TwoPhaseState and determine the range
  * of valid XIDs present.  This is run during database startup, after we
- * have completed reading WAL.  ShmemVariableCache->nextXid has been set to
+ * have completed reading WAL.  TransamVariables->nextXid has been set to
  * one more than the highest XID for which evidence exists in WAL.
  *
  * We throw away any prepared xacts with main XID beyond nextXid --- if any
@@ -1967,7 +1967,7 @@ restoreTwoPhaseData(void)
  * backup should be rolled in.
  *
  * Our other responsibility is to determine and return the oldest valid XID
- * among the prepared xacts (if none, return ShmemVariableCache->nextXid).
+ * among the prepared xacts (if none, return TransamVariables->nextXid).
  * This is needed to synchronize pg_subtrans startup properly.
  *
  * If xids_p and nxids_p are not NULL, pointer to a palloc'd array of all
@@ -1977,7 +1977,7 @@ restoreTwoPhaseData(void)
 TransactionId
 PrescanPreparedTransactions(TransactionId **xids_p, int *nxids_p)
 {
-	FullTransactionId nextXid = ShmemVariableCache->nextXid;
+	FullTransactionId nextXid = TransamVariables->nextXid;
 	TransactionId origNextXid = XidFromFullTransactionId(nextXid);
 	TransactionId result = origNextXid;
 	TransactionId *xids = NULL;
@@ -2196,7 +2196,7 @@ RecoverPreparedTransactions(void)
  *
  * If setParent is true, set up subtransaction parent linkages.
  *
- * If setNextXid is true, set ShmemVariableCache->nextXid to the newest
+ * If setNextXid is true, set TransamVariables->nextXid to the newest
  * value scanned.
  */
 static char *
@@ -2205,7 +2205,7 @@ ProcessTwoPhaseBuffer(TransactionId xid,
 					  bool fromdisk,
 					  bool setParent, bool setNextXid)
 {
-	FullTransactionId nextXid = ShmemVariableCache->nextXid;
+	FullTransactionId nextXid = TransamVariables->nextXid;
 	TransactionId origNextXid = XidFromFullTransactionId(nextXid);
 	TransactionId *subxids;
 	char	   *buf;

--- a/src/backend/access/transam/varsup.c
+++ b/src/backend/access/transam/varsup.c
@@ -30,18 +30,18 @@
 /* Number of OIDs to prefetch (preallocate) per XLOG write */
 #define VAR_OID_PREFETCH		8192
 
-/* pointer to "variable cache" in shared memory (set up by shmem.c) */
-VariableCache ShmemVariableCache = NULL;
+/* pointer to variables struct in shared memory */
+TransamVariablesData *TransamVariables = NULL;
 
 GetNewObjectId_hook_type GetNewObjectId_hook = NULL;
 
 /*
- * Initialization of shared memory for ShmemVariableCache.
+ * Initialization of shared memory for TransamVariables.
  */
 Size
 VarsupShmemSize(void)
 {
-	return sizeof(VariableCacheData);
+	return sizeof(TransamVariablesData);
 }
 
 void
@@ -50,13 +50,13 @@ VarsupShmemInit(void)
 	bool		found;
 
 	/* Initialize our shared state struct */
-	ShmemVariableCache = ShmemInitStruct("ShmemVariableCache",
-										 sizeof(VariableCacheData),
-										 &found);
+	TransamVariables = ShmemInitStruct("TransamVariables",
+									   sizeof(TransamVariablesData),
+									   &found);
 	if (!IsUnderPostmaster)
 	{
 		Assert(!found);
-		memset(ShmemVariableCache, 0, sizeof(VariableCacheData));
+		memset(TransamVariables, 0, sizeof(TransamVariablesData));
 	}
 	else
 		Assert(found);
@@ -105,7 +105,7 @@ GetNewTransactionId(bool isSubXact)
 
 	LWLockAcquire(XidGenLock, LW_EXCLUSIVE);
 
-	full_xid = ShmemVariableCache->nextXid;
+	full_xid = TransamVariables->nextXid;
 	xid = XidFromFullTransactionId(full_xid);
 
 	/*----------
@@ -121,7 +121,7 @@ GetNewTransactionId(bool isSubXact)
 	 * Note that this coding also appears in GetNewMultiXactId.
 	 *----------
 	 */
-	if (TransactionIdFollowsOrEquals(xid, ShmemVariableCache->xidVacLimit))
+	if (TransactionIdFollowsOrEquals(xid, TransamVariables->xidVacLimit))
 	{
 		/*
 		 * For safety's sake, we release XidGenLock while sending signals,
@@ -130,10 +130,10 @@ GetNewTransactionId(bool isSubXact)
 		 * possibility of deadlock while doing get_database_name(). First,
 		 * copy all the shared values we'll need in this path.
 		 */
-		TransactionId xidWarnLimit = ShmemVariableCache->xidWarnLimit;
-		TransactionId xidStopLimit = ShmemVariableCache->xidStopLimit;
-		TransactionId xidWrapLimit = ShmemVariableCache->xidWrapLimit;
-		Oid			oldest_datoid = ShmemVariableCache->oldestXidDB;
+		TransactionId xidWarnLimit = TransamVariables->xidWarnLimit;
+		TransactionId xidStopLimit = TransamVariables->xidStopLimit;
+		TransactionId xidWrapLimit = TransamVariables->xidWrapLimit;
+		Oid			oldest_datoid = TransamVariables->oldestXidDB;
 
 		LWLockRelease(XidGenLock);
 
@@ -189,7 +189,7 @@ GetNewTransactionId(bool isSubXact)
 
 		/* Re-acquire lock and start over */
 		LWLockAcquire(XidGenLock, LW_EXCLUSIVE);
-		full_xid = ShmemVariableCache->nextXid;
+		full_xid = TransamVariables->nextXid;
 		xid = XidFromFullTransactionId(full_xid);
 	}
 
@@ -212,7 +212,7 @@ GetNewTransactionId(bool isSubXact)
 	 * want the next incoming transaction to try it again.  We cannot assign
 	 * more XIDs until there is CLOG space for them.
 	 */
-	FullTransactionIdAdvance(&ShmemVariableCache->nextXid);
+	FullTransactionIdAdvance(&TransamVariables->nextXid);
 
 	/*
 	 * We must store the new XID into the shared ProcArray before releasing
@@ -291,7 +291,7 @@ ReadNextFullTransactionId(void)
 	FullTransactionId fullXid;
 
 	LWLockAcquire(XidGenLock, LW_SHARED);
-	fullXid = ShmemVariableCache->nextXid;
+	fullXid = TransamVariables->nextXid;
 	LWLockRelease(XidGenLock);
 
 	return fullXid;
@@ -316,7 +316,7 @@ AdvanceNextFullTransactionIdPastXid(TransactionId xid)
 	Assert(AmStartupProcess() || !IsUnderPostmaster);
 
 	/* Fast return if this isn't an xid high enough to move the needle. */
-	next_xid = XidFromFullTransactionId(ShmemVariableCache->nextXid);
+	next_xid = XidFromFullTransactionId(TransamVariables->nextXid);
 	if (!TransactionIdFollowsOrEquals(xid, next_xid))
 		return;
 
@@ -329,7 +329,7 @@ AdvanceNextFullTransactionIdPastXid(TransactionId xid)
 	 * point in the WAL stream.
 	 */
 	TransactionIdAdvance(xid);
-	epoch = EpochFromFullTransactionId(ShmemVariableCache->nextXid);
+	epoch = EpochFromFullTransactionId(TransamVariables->nextXid);
 	if (unlikely(xid < next_xid))
 		++epoch;
 	newNextFullXid = FullTransactionIdFromEpochAndXid(epoch, xid);
@@ -339,7 +339,7 @@ AdvanceNextFullTransactionIdPastXid(TransactionId xid)
 	 * concurrent readers.
 	 */
 	LWLockAcquire(XidGenLock, LW_EXCLUSIVE);
-	ShmemVariableCache->nextXid = newNextFullXid;
+	TransamVariables->nextXid = newNextFullXid;
 	LWLockRelease(XidGenLock);
 }
 
@@ -356,10 +356,10 @@ void
 AdvanceOldestClogXid(TransactionId oldest_datfrozenxid)
 {
 	LWLockAcquire(XactTruncationLock, LW_EXCLUSIVE);
-	if (TransactionIdPrecedes(ShmemVariableCache->oldestClogXid,
+	if (TransactionIdPrecedes(TransamVariables->oldestClogXid,
 							  oldest_datfrozenxid))
 	{
-		ShmemVariableCache->oldestClogXid = oldest_datfrozenxid;
+		TransamVariables->oldestClogXid = oldest_datfrozenxid;
 	}
 	LWLockRelease(XactTruncationLock);
 }
@@ -442,13 +442,13 @@ SetTransactionIdLimit(TransactionId oldest_datfrozenxid, Oid oldest_datoid)
 
 	/* Grab lock for just long enough to set the new limit values */
 	LWLockAcquire(XidGenLock, LW_EXCLUSIVE);
-	ShmemVariableCache->oldestXid = oldest_datfrozenxid;
-	ShmemVariableCache->xidVacLimit = xidVacLimit;
-	ShmemVariableCache->xidWarnLimit = xidWarnLimit;
-	ShmemVariableCache->xidStopLimit = xidStopLimit;
-	ShmemVariableCache->xidWrapLimit = xidWrapLimit;
-	ShmemVariableCache->oldestXidDB = oldest_datoid;
-	curXid = XidFromFullTransactionId(ShmemVariableCache->nextXid);
+	TransamVariables->oldestXid = oldest_datfrozenxid;
+	TransamVariables->xidVacLimit = xidVacLimit;
+	TransamVariables->xidWarnLimit = xidWarnLimit;
+	TransamVariables->xidStopLimit = xidStopLimit;
+	TransamVariables->xidWrapLimit = xidWrapLimit;
+	TransamVariables->oldestXidDB = oldest_datoid;
+	curXid = XidFromFullTransactionId(TransamVariables->nextXid);
 	LWLockRelease(XidGenLock);
 
 	/* Log the info */
@@ -524,10 +524,10 @@ ForceTransactionIdLimitUpdate(void)
 
 	/* Locking is probably not really necessary, but let's be careful */
 	LWLockAcquire(XidGenLock, LW_SHARED);
-	nextXid = XidFromFullTransactionId(ShmemVariableCache->nextXid);
-	xidVacLimit = ShmemVariableCache->xidVacLimit;
-	oldestXid = ShmemVariableCache->oldestXid;
-	oldestXidDB = ShmemVariableCache->oldestXidDB;
+	nextXid = XidFromFullTransactionId(TransamVariables->nextXid);
+	xidVacLimit = TransamVariables->xidVacLimit;
+	oldestXid = TransamVariables->oldestXid;
+	oldestXidDB = TransamVariables->oldestXidDB;
 	LWLockRelease(XidGenLock);
 
 	if (!TransactionIdIsNormal(oldestXid))
@@ -577,40 +577,40 @@ GetNewObjectId(void)
 	 * available for automatic assignment during initdb, while ensuring they
 	 * will never conflict with user-assigned OIDs.
 	 */
-	if (ShmemVariableCache->nextOid < ((Oid) FirstNormalObjectId))
+	if (TransamVariables->nextOid < ((Oid) FirstNormalObjectId))
 	{
 		if (IsPostmasterEnvironment)
 		{
 			/* wraparound, or first post-initdb assignment, in normal mode */
-			ShmemVariableCache->nextOid = FirstNormalObjectId;
-			ShmemVariableCache->oidCount = 0;
+			TransamVariables->nextOid = FirstNormalObjectId;
+			TransamVariables->oidCount = 0;
 		}
 		else
 		{
 			/* we may be bootstrapping, so don't enforce the full range */
-			if (ShmemVariableCache->nextOid < ((Oid) FirstGenbkiObjectId))
+			if (TransamVariables->nextOid < ((Oid) FirstGenbkiObjectId))
 			{
 				/* wraparound in standalone mode (unlikely but possible) */
-				ShmemVariableCache->nextOid = FirstNormalObjectId;
-				ShmemVariableCache->oidCount = 0;
+				TransamVariables->nextOid = FirstNormalObjectId;
+				TransamVariables->oidCount = 0;
 			}
 		}
 	}
 
 	if (GetNewObjectId_hook)
-		GetNewObjectId_hook(ShmemVariableCache);
+		GetNewObjectId_hook(TransamVariables);
 
 	/* If we run out of logged for use oids then we must log more */
-	if (ShmemVariableCache->oidCount == 0)
+	if (TransamVariables->oidCount == 0)
 	{
-		XLogPutNextOid(ShmemVariableCache->nextOid + VAR_OID_PREFETCH);
-		ShmemVariableCache->oidCount = VAR_OID_PREFETCH;
+		XLogPutNextOid(TransamVariables->nextOid + VAR_OID_PREFETCH);
+		TransamVariables->oidCount = VAR_OID_PREFETCH;
 	}
 
-	result = ShmemVariableCache->nextOid;
+	result = TransamVariables->nextOid;
 
-	(ShmemVariableCache->nextOid)++;
-	(ShmemVariableCache->oidCount)--;
+	(TransamVariables->nextOid)++;
+	(TransamVariables->oidCount)--;
 
 	LWLockRelease(OidGenLock);
 
@@ -641,12 +641,12 @@ SetNextObjectId(Oid nextOid)
 	/* Taking the lock is, therefore, just pro forma; but do it anyway */
 	LWLockAcquire(OidGenLock, LW_EXCLUSIVE);
 
-	if (ShmemVariableCache->nextOid > nextOid)
+	if (TransamVariables->nextOid > nextOid)
 		elog(ERROR, "too late to advance OID counter to %u, it is now %u",
-			 nextOid, ShmemVariableCache->nextOid);
+			 nextOid, TransamVariables->nextOid);
 
-	ShmemVariableCache->nextOid = nextOid;
-	ShmemVariableCache->oidCount = 0;
+	TransamVariables->nextOid = nextOid;
+	TransamVariables->oidCount = 0;
 
 	LWLockRelease(OidGenLock);
 }
@@ -673,7 +673,7 @@ StopGeneratingPinnedObjectIds(void)
  * Assert that xid is between [oldestXid, nextXid], which is the range we
  * expect XIDs coming from tables etc to be in.
  *
- * As ShmemVariableCache->oldestXid could change just after this call without
+ * As TransamVariables->oldestXid could change just after this call without
  * further precautions, and as a wrapped-around xid could again fall within
  * the valid range, this assertion can only detect if something is definitely
  * wrong, but not establish correctness.
@@ -708,8 +708,8 @@ AssertTransactionIdInAllowableRange(TransactionId xid)
 	 * before we see the updated nextXid value.
 	 */
 	pg_memory_barrier();
-	oldest_xid = ShmemVariableCache->oldestXid;
-	next_xid = XidFromFullTransactionId(ShmemVariableCache->nextXid);
+	oldest_xid = TransamVariables->oldestXid;
+	next_xid = XidFromFullTransactionId(TransamVariables->nextXid);
 
 	Assert(TransactionIdFollowsOrEquals(xid, oldest_xid) ||
 		   TransactionIdPrecedesOrEquals(xid, next_xid));

--- a/src/backend/access/transam/xlogreader.c
+++ b/src/backend/access/transam/xlogreader.c
@@ -2182,8 +2182,8 @@ XLogRecGetFullXid(XLogReaderState *record)
 	Assert(AmStartupProcess() || !IsUnderPostmaster);
 
 	xid = XLogRecGetXid(record);
-	next_xid = XidFromFullTransactionId(ShmemVariableCache->nextXid);
-	epoch = EpochFromFullTransactionId(ShmemVariableCache->nextXid);
+	next_xid = XidFromFullTransactionId(TransamVariables->nextXid);
+	epoch = EpochFromFullTransactionId(TransamVariables->nextXid);
 
 	/*
 	 * If xid is numerically greater than next_xid, it has to be from the last

--- a/src/backend/access/transam/xlogrecovery.c
+++ b/src/backend/access/transam/xlogrecovery.c
@@ -1869,7 +1869,7 @@ ApplyWalRecord(XLogReaderState *xlogreader, XLogRecord *record, TimeLineID *repl
 	error_context_stack = &errcallback;
 
 	/*
-	 * ShmemVariableCache->nextXid must be beyond record's xid.
+	 * TransamVariables->nextXid must be beyond record's xid.
 	 */
 	AdvanceNextFullTransactionIdPastXid(record->xl_xid);
 

--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -2640,8 +2640,8 @@ deleted:
 	 *
 	 * Even if we didn't vacuum anything, it may still be important to do
 	 * this, because one indirect effect of vac_update_datfrozenxid() is to
-	 * update ShmemVariableCache->xidVacLimit.  That might need to be done
-	 * even if we haven't vacuumed anything, because relations with older
+	 * update TransamVariables->xidVacLimit.  That might need to be done even
+	 * if we haven't vacuumed anything, because relations with older
 	 * relfrozenxid values or other databases with older datfrozenxid values
 	 * might have been dropped, allowing xidVacLimit to advance.
 	 *

--- a/src/backend/storage/lmgr/predicate.c
+++ b/src/backend/storage/lmgr/predicate.c
@@ -3390,7 +3390,7 @@ ReleasePredicateLocks(bool isCommit, bool isReadOnlySafe)
 	 * transaction to complete before freeing some RAM; correctness of visible
 	 * behavior is not affected.
 	 */
-	MySerializableXact->finishedBefore = XidFromFullTransactionId(ShmemVariableCache->nextXid);
+	MySerializableXact->finishedBefore = XidFromFullTransactionId(TransamVariables->nextXid);
 
 	/*
 	 * If it's not a commit it's either a rollback or a read-only transaction

--- a/src/backend/utils/adt/xid8funcs.c
+++ b/src/backend/utils/adt/xid8funcs.c
@@ -126,8 +126,8 @@ TransactionIdInRecentPast(FullTransactionId fxid, TransactionId *extracted_xid)
 						(unsigned long long) U64FromFullTransactionId(fxid))));
 
 	/*
-	 * ShmemVariableCache->oldestClogXid is protected by XactTruncationLock,
-	 * but we don't acquire that lock here.  Instead, we require the caller to
+	 * TransamVariables->oldestClogXid is protected by XactTruncationLock, but
+	 * we don't acquire that lock here.  Instead, we require the caller to
 	 * acquire it, because the caller is presumably going to look up the
 	 * returned XID.  If we took and released the lock within this function, a
 	 * CLOG truncation could occur before the caller finished with the XID.
@@ -137,12 +137,12 @@ TransactionIdInRecentPast(FullTransactionId fxid, TransactionId *extracted_xid)
 	/*
 	 * If the transaction ID has wrapped around, it's definitely too old to
 	 * determine the commit status.  Otherwise, we can compare it to
-	 * ShmemVariableCache->oldestClogXid to determine whether the relevant
-	 * CLOG entry is guaranteed to still exist.
+	 * TransamVariables->oldestClogXid to determine whether the relevant CLOG
+	 * entry is guaranteed to still exist.
 	 */
 	if (xid_epoch + 1 < now_epoch
 		|| (xid_epoch + 1 == now_epoch && xid < now_epoch_next_xid)
-		|| TransactionIdPrecedes(xid, ShmemVariableCache->oldestClogXid))
+		|| TransactionIdPrecedes(xid, TransamVariables->oldestClogXid))
 		return false;
 
 	return true;

--- a/src/include/access/transam.h
+++ b/src/include/access/transam.h
@@ -197,7 +197,7 @@ FullTransactionIdAdvance(FullTransactionId *dest)
 #define FirstNormalObjectId		16384
 
 /*
- * VariableCache is a data structure in shared memory that is used to track
+ * TransamVariables is a data structure in shared memory that is used to track
  * OID and XID assignment state.  For largely historical reasons, there is
  * just one struct with different fields that are protected by different
  * LWLocks.
@@ -206,7 +206,7 @@ FullTransactionIdAdvance(FullTransactionId *dest)
  * used just to generate useful messages when xidWarnLimit or xidStopLimit
  * are exceeded.
  */
-typedef struct VariableCacheData
+typedef struct TransamVariablesData
 {
 	/*
 	 * These fields are protected by OidGenLock.
@@ -258,9 +258,9 @@ typedef struct VariableCacheData
 	 * updated the start.
 	 */
 	Oid			tempOidStart;
-} VariableCacheData;
+} TransamVariablesData;
 
-typedef VariableCacheData *VariableCache;
+typedef TransamVariablesData *VariableCache;
 
 
 /* ----------------
@@ -272,7 +272,7 @@ typedef VariableCacheData *VariableCache;
 extern bool TransactionStartedDuringRecovery(void);
 
 /* in transam/varsup.c */
-extern PGDLLIMPORT VariableCache ShmemVariableCache;
+extern PGDLLIMPORT TransamVariablesData *TransamVariables;
 
 /*
  * prototypes for functions in transam/transam.c

--- a/src/include/storage/standby.h
+++ b/src/include/storage/standby.h
@@ -80,7 +80,7 @@ typedef struct RunningTransactionsData
 	int			xcnt;			/* # of xact ids in xids[] */
 	int			subxcnt;		/* # of subxact ids in xids[] */
 	bool		subxid_overflow;	/* snapshot overflowed, subxids missing */
-	TransactionId nextXid;		/* xid from ShmemVariableCache->nextXid */
+	TransactionId nextXid;		/* xid from TransamVariables->nextXid */
 	TransactionId oldestRunningXid; /* *not* oldestXmin */
 	TransactionId latestCompletedXid;	/* so we can set xmax */
 

--- a/src/include/storage/standbydefs.h
+++ b/src/include/storage/standbydefs.h
@@ -49,7 +49,7 @@ typedef struct xl_running_xacts
 	int			xcnt;			/* # of xact ids in xids[] */
 	int			subxcnt;		/* # of subxact ids in xids[] */
 	bool		subxid_overflow;	/* snapshot overflowed, subxids missing */
-	TransactionId nextXid;		/* xid from ShmemVariableCache->nextXid */
+	TransactionId nextXid;		/* xid from TransamVariables->nextXid */
 	TransactionId oldestRunningXid; /* *not* oldestXmin */
 	TransactionId latestCompletedXid;	/* so we can set xmax */
 

--- a/src/test/modules/xid_wraparound/xid_wraparound.c
+++ b/src/test/modules/xid_wraparound/xid_wraparound.c
@@ -203,7 +203,7 @@ consume_xids_shortcut(void)
 	uint32		consumed;
 
 	LWLockAcquire(XidGenLock, LW_EXCLUSIVE);
-	nextXid = ShmemVariableCache->nextXid;
+	nextXid = TransamVariables->nextXid;
 
 	/*
 	 * Go slow near the "interesting values". The interesting zones include 5
@@ -211,7 +211,7 @@ consume_xids_shortcut(void)
 	 */
 	consumed = XidSkip(nextXid);
 	if (consumed > 0)
-		ShmemVariableCache->nextXid.value += (uint64) consumed;
+		TransamVariables->nextXid.value += (uint64) consumed;
 
 	LWLockRelease(XidGenLock);
 

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -2832,6 +2832,7 @@ TocEntry
 TokenAuxData
 TokenizedAuthLine
 TrackItem
+TransamVariablesData
 TransApplyAction
 TransInvalidationInfo
 TransState
@@ -2962,8 +2963,6 @@ VarString
 VarStringSortSupport
 Variable
 VariableAssignHook
-VariableCache
-VariableCacheData
 VariableSetKind
 VariableSetStmt
 VariableShowStmt


### PR DESCRIPTION
The old name was misleading: It's not a cache, the values kept in the struct are the authoritative source.

Reviewed-by: Tristan Partin, Richard Guo
Discussion: https://www.postgresql.org/message-id/6537d63d-4bb5-46f8-9b5d-73a8ba4720ab@iki.fi (cherry picked from commit b31ba5310b5176402b60abc0454a033b1210ab75)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
