### PR TITLE
Convert README to Markdown.

### DIFF
--- a/README
+++ b/README
@@ -12,11 +12,11 @@ and functions.  This distribution also contains C language bindings.
 Copyright and license information can be found in the file COPYRIGHT.
 
 General documentation about this version of PostgreSQL can be found at:
-https://www.postgresql.org/docs/devel/
+<https://www.postgresql.org/docs/devel/>
 In particular, information about building PostgreSQL from the source
 code can be found at:
-https://www.postgresql.org/docs/devel/installation.html
+<https://www.postgresql.org/docs/devel/installation.html>
 
 The latest version of this software, and related software, may be
-obtained at https://www.postgresql.org/download/.  For more information
-look at our web site located at https://www.postgresql.org/.
+obtained at <https://www.postgresql.org/download/>.  For more information
+look at our web site located at <https://www.postgresql.org/>.


### PR DESCRIPTION
This is a first step toward modernizing our README file.  Some popular developer platforms support rendering README.md files, so a direct conversion to Markdown seems like a good place to start. The intent is to keep this file legible as plain text even as it accumulates more content.

Suggested-by: Andrew Atkinson
Reviewed-by: Tom Lane, Daniel Gustafsson, Joe Conway Discussion: https://postgr.es/m/CAG6XLEmGE95DdKqjk%2BDd9vC8mfN7BnV2WFgYk_9ovW6ikN0YSg%40mail.gmail.com (cherry picked from commit 363eb059966d0be0a41c206cee40dfd21eb73251)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
