### PR TITLE
Support adding users to T-SQL db_owner database role

### DIFF
--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -227,8 +227,7 @@ getBabelfishRolesQuery(PGconn *conn, PQExpBuffer buf, char *role_catalog,
 		pfree(babel_init_user);
 	}
 	appendPQExpBufferStr(buf,
-						 "SELECT rolname FROM sys.babelfish_authid_user_ext "
-						 "UNION ");
+						 "SELECT rolname FROM sys.babelfish_authid_user_ext ");
 	/* Only dump users of the specific logical database we are currently dumping. */
 	if (bbf_db_name != NULL)
 	{
@@ -239,15 +238,13 @@ getBabelfishRolesQuery(PGconn *conn, PQExpBuffer buf, char *role_catalog,
 		char *escaped_bbf_db_name = pg_malloc(2 * strlen(bbf_db_name) + 1);
 
 		PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
-		appendPQExpBuffer(buf,
-						  "WHERE database_name = '%s' "
-						  "UNION ",
-						  escaped_bbf_db_name);
+		appendPQExpBuffer(buf, "WHERE database_name = '%s' ", escaped_bbf_db_name);
 		pfree(escaped_bbf_db_name);
 	}
 
 	/* Append roles associated with db_owner members which are not present in bbf catalogs */
 	appendPQExpBuffer(buf,
+					  "UNION "
 					  "SELECT pr.rolname "
 					  "FROM ( "
 					  "SELECT DISTINCT pr.rolname AS member_role "
@@ -348,9 +345,7 @@ getBabelfishRoleMembershipQuery(PGconn *conn, PQExpBuffer buf,
 							 "SELECT 'securityadmin' AS rolname UNION "
 							 "SELECT 'dbcreator' AS rolname UNION ");
 	appendPQExpBuffer(buf,
-					  "SELECT rolname FROM sys.babelfish_authid_user_ext "
-					  "UNION ");
-
+					  "SELECT rolname FROM sys.babelfish_authid_user_ext ");
 	/* Only dump users of the specific logical database we are currently dumping. */
 	if (bbf_db_name != NULL)
 	{
@@ -361,15 +356,13 @@ getBabelfishRoleMembershipQuery(PGconn *conn, PQExpBuffer buf,
 		char *escaped_bbf_db_name = pg_malloc(2 * strlen(bbf_db_name) + 1);
 
 		PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
-		appendPQExpBuffer(buf,
-						  "WHERE database_name = '%s' "
-						  "UNION ",
-						  escaped_bbf_db_name);
+		appendPQExpBuffer(buf, "WHERE database_name = '%s' ", escaped_bbf_db_name);
 		pfree(escaped_bbf_db_name);
 	}
 
 		/* Append roles associated with db_owner members which are not present in bbf catalogs */
 	appendPQExpBuffer(buf,
+					  "UNION "
 					  "SELECT pr.rolname "
 					  "FROM ( "
 					  "SELECT DISTINCT pr.rolname AS member_role "

--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -271,7 +271,7 @@ getBabelfishRolesQuery(PGconn *conn, PQExpBuffer buf, char *role_catalog,
 
 	appendPQExpBuffer(buf,
 					  ") AS db_owner_members "
-					  "JOIN pg_roles pr ON pr.rolname = db_owner_members.member_role || '_obj' ");
+					  "JOIN pg_roles pr ON pr.rolname = sys.babelfish_truncate_identifier(db_owner_members.member_role || '_obj') ");
 
 	appendPQExpBuffer(buf, "), "
 					  "bbf_roles AS (SELECT rc.* FROM %s rc INNER JOIN bbf_catalog bcat "
@@ -389,7 +389,7 @@ getBabelfishRoleMembershipQuery(PGconn *conn, PQExpBuffer buf,
 
 	appendPQExpBuffer(buf,
 					  ") AS db_owner_members "
-					  "JOIN pg_roles pr ON pr.rolname = db_owner_members.member_role || '_obj' ");
+					  "JOIN pg_roles pr ON pr.rolname = sys.babelfish_truncate_identifier(db_owner_members.member_role || '_obj') ");
 
 	appendPQExpBuffer(buf, "), "
 					  "bbf_roles AS (SELECT rc.* FROM %s rc INNER JOIN bbf_catalog bcat "

--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -227,7 +227,8 @@ getBabelfishRolesQuery(PGconn *conn, PQExpBuffer buf, char *role_catalog,
 		pfree(babel_init_user);
 	}
 	appendPQExpBufferStr(buf,
-						 "SELECT rolname FROM sys.babelfish_authid_user_ext ");
+						 "SELECT rolname FROM sys.babelfish_authid_user_ext "
+						 "UNION ");
 	/* Only dump users of the specific logical database we are currently dumping. */
 	if (bbf_db_name != NULL)
 	{
@@ -238,9 +239,43 @@ getBabelfishRolesQuery(PGconn *conn, PQExpBuffer buf, char *role_catalog,
 		char *escaped_bbf_db_name = pg_malloc(2 * strlen(bbf_db_name) + 1);
 
 		PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
-		appendPQExpBuffer(buf, "WHERE database_name = '%s' ", escaped_bbf_db_name);
+		appendPQExpBuffer(buf,
+						  "WHERE database_name = '%s' "
+						  "UNION ",
+						  escaped_bbf_db_name);
 		pfree(escaped_bbf_db_name);
 	}
+
+	/* Append roles associated with db_owner members which are not present in bbf catalogs */
+	appendPQExpBuffer(buf,
+					  "SELECT pr.rolname "
+					  "FROM ( "
+					  "SELECT DISTINCT pr.rolname AS member_role "
+					  "FROM sys.babelfish_authid_user_ext ta "
+					  "JOIN pg_roles r ON r.rolname = ta.rolname "
+					  "JOIN pg_auth_members m ON r.oid = m.roleid "
+					  "JOIN pg_roles pr ON pr.oid = m.member "
+					  "WHERE pr.rolname != ta.rolname "
+					  "AND ta.orig_username = 'db_owner' ");
+
+	/* Only dump users of the specific logical database we are currently dumping. */
+	if (bbf_db_name != NULL)
+	{
+		/*
+		 * Get escaped bbf_db_name to handle special characters in it.
+		 * 2*strlen+1 bytes are required for PQescapeString according to the documentation.
+		 */
+		char *escaped_bbf_db_name = pg_malloc(2 * strlen(bbf_db_name) + 1);
+
+		PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
+		appendPQExpBuffer(buf, "AND ta.database_name = '%s' ", escaped_bbf_db_name);
+		pfree(escaped_bbf_db_name);
+	}
+
+	appendPQExpBuffer(buf,
+					  ") AS db_owner_members "
+					  "JOIN pg_roles pr ON pr.rolname = db_owner_members.member_role || '_obj' ");
+
 	appendPQExpBuffer(buf, "), "
 					  "bbf_roles AS (SELECT rc.* FROM %s rc INNER JOIN bbf_catalog bcat "
 					  "ON rc.rolname = bcat.rolname) ", role_catalog);
@@ -313,7 +348,9 @@ getBabelfishRoleMembershipQuery(PGconn *conn, PQExpBuffer buf,
 							 "SELECT 'securityadmin' AS rolname UNION "
 							 "SELECT 'dbcreator' AS rolname UNION ");
 	appendPQExpBuffer(buf,
-					  "SELECT rolname FROM sys.babelfish_authid_user_ext ");
+					  "SELECT rolname FROM sys.babelfish_authid_user_ext "
+					  "UNION ");
+
 	/* Only dump users of the specific logical database we are currently dumping. */
 	if (bbf_db_name != NULL)
 	{
@@ -324,9 +361,43 @@ getBabelfishRoleMembershipQuery(PGconn *conn, PQExpBuffer buf,
 		char *escaped_bbf_db_name = pg_malloc(2 * strlen(bbf_db_name) + 1);
 
 		PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
-		appendPQExpBuffer(buf, "WHERE database_name = '%s' ", escaped_bbf_db_name);
+		appendPQExpBuffer(buf,
+						  "WHERE database_name = '%s' "
+						  "UNION ",
+						  escaped_bbf_db_name);
 		pfree(escaped_bbf_db_name);
 	}
+
+		/* Append roles associated with db_owner members which are not present in bbf catalogs */
+	appendPQExpBuffer(buf,
+					  "SELECT pr.rolname "
+					  "FROM ( "
+					  "SELECT DISTINCT pr.rolname AS member_role "
+					  "FROM sys.babelfish_authid_user_ext ta "
+					  "JOIN pg_roles r ON r.rolname = ta.rolname "
+					  "JOIN pg_auth_members m ON r.oid = m.roleid "
+					  "JOIN pg_roles pr ON pr.oid = m.member "
+					  "WHERE pr.rolname != ta.rolname "
+					  "AND ta.orig_username = 'db_owner' ");
+
+	/* Only dump users of the specific logical database we are currently dumping. */
+	if (bbf_db_name != NULL)
+	{
+		/*
+		 * Get escaped bbf_db_name to handle special characters in it.
+		 * 2*strlen+1 bytes are required for PQescapeString according to the documentation.
+		 */
+		char *escaped_bbf_db_name = pg_malloc(2 * strlen(bbf_db_name) + 1);
+
+		PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
+		appendPQExpBuffer(buf, "AND ta.database_name = '%s' ", escaped_bbf_db_name);
+		pfree(escaped_bbf_db_name);
+	}
+
+	appendPQExpBuffer(buf,
+					  ") AS db_owner_members "
+					  "JOIN pg_roles pr ON pr.rolname = db_owner_members.member_role || '_obj' ");
+
 	appendPQExpBuffer(buf, "), "
 					  "bbf_roles AS (SELECT rc.* FROM %s rc INNER JOIN bbf_catalog bcat "
 					  "ON rc.rolname = bcat.rolname) ", role_catalog);


### PR DESCRIPTION
This commit adds support in Babelfish dump utility to dump the linked
roles associated with members of db_owner role that are not present in
Babelfish catalogs.

Task: BABEL-4899
Signed-off-by: Sharu Goel <goelshar@amazon.com>
