### PR TITLE
Adding Grantor Information in sys.babelfish_schema_permissions catalog

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -173,6 +173,7 @@ static void recordExtensionInitPrivWorker(Oid objoid, Oid classoid, int objsubid
 
 tsql_has_linked_srv_permissions_hook_type tsql_has_linked_srv_permissions_hook = NULL;
 bbf_execute_grantstmt_as_dbsecadmin_hook_type bbf_execute_grantstmt_as_dbsecadmin_hook = NULL;
+update_bbf_schema_permissions_catalog_hook_type update_bbf_schema_permissions_catalog_hook = NULL;
 pltsql_allow_storing_init_privs_hook_type pltsql_allow_storing_init_privs_hook = NULL;
 /*
  * If is_grant is true, adds the given privileges for the list of
@@ -2040,7 +2041,7 @@ ExecGrant_Relation(InternalGrant *istmt)
 			{
 				(*bbf_execute_grantstmt_as_dbsecadmin_hook) (objtype, relOid, ownerId, this_privileges, &grantorId, &avail_goptions);
 			}
-
+			
 			/*
 			 * Restrict the privileges to what we can actually grant, and emit
 			 * the standards-mandated warning and error messages.
@@ -2052,6 +2053,16 @@ ExecGrant_Relation(InternalGrant *istmt)
 										 NameStr(pg_class_tuple->relname),
 										 0, NULL);
 
+			/* Call the hook to add the permission in bbf_schema_permissions catalog 
+			*  If the hook returns false, indicates that object-level and schema-level grants both are present and schema-level grant is revoked.
+			*  In such case we remove schema-level entry from the bbf_schema_permissions catalog but skip the execution of revoke as object-level grants exist.
+			*/
+			if (update_bbf_schema_permissions_catalog_hook && !(*update_bbf_schema_permissions_catalog_hook) (this_privileges, istmt->is_grant, istmt->grantees,
+				istmt->col_privs, pg_class_tuple->oid, GetUserNameFromId(grantorId, false), 
+				istmt->grant_option, GetUserNameFromId(ownerId, false), istmt->objtype))
+			{
+				return;
+			}							 
 			/*
 			 * Generate new ACL.
 			 */
@@ -2258,6 +2269,7 @@ ExecGrant_common(InternalGrant *istmt, Oid classid, AclMode default_privs,
 			(*bbf_execute_grantstmt_as_dbsecadmin_hook) (get_object_type(classid, objectid), objectid, ownerId, istmt->privileges, &grantorId, &avail_goptions);
 		}
 
+
 		nameDatum = SysCacheGetAttrNotNull(cacheid, tuple,
 										   get_object_attnum_name(classid));
 
@@ -2271,6 +2283,17 @@ ExecGrant_common(InternalGrant *istmt, Oid classid, AclMode default_privs,
 									 objectid, grantorId, get_object_type(classid, objectid),
 									 NameStr(*DatumGetName(nameDatum)),
 									 0, NULL);
+
+		/* Call the hook to add the permission in bbf_schema_permissions catalog 
+		*  If the hook returns false, indicates that object-level and schema-level grants both are present and schema-level grant is revoked.
+		*  In such case we remove schema-level entry from the bbf_schema_permissions catalog but skip the execution of revoke as object-level grants exist.
+		*/
+		if ((istmt->objtype == OBJECT_PROCEDURE || istmt->objtype == OBJECT_FUNCTION) && update_bbf_schema_permissions_catalog_hook && !(*update_bbf_schema_permissions_catalog_hook) (this_privileges, istmt->is_grant, istmt->grantees,
+				istmt->col_privs, objectid, GetUserNameFromId(grantorId, false), 
+			istmt->grant_option, GetUserNameFromId(ownerId, false), istmt->objtype))
+		{
+			return;
+		}
 
 		/*
 		 * Generate new ACL.

--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -2041,7 +2041,7 @@ ExecGrant_Relation(InternalGrant *istmt)
 			{
 				(*bbf_execute_grantstmt_as_dbsecadmin_hook) (objtype, relOid, ownerId, this_privileges, &grantorId, &avail_goptions);
 			}
-			
+
 			/*
 			 * Restrict the privileges to what we can actually grant, and emit
 			 * the standards-mandated warning and error messages.
@@ -2053,10 +2053,11 @@ ExecGrant_Relation(InternalGrant *istmt)
 										 NameStr(pg_class_tuple->relname),
 										 0, NULL);
 
-			/* Call the hook to add the permission in bbf_schema_permissions catalog 
-			*  If the hook returns false, indicates that object-level and schema-level grants both are present and schema-level grant is revoked.
-			*  In such case we remove schema-level entry from the bbf_schema_permissions catalog but skip the execution of revoke as object-level grants exist.
-			*/
+			/* 
+			 * Call the hook to add the permission in bbf_schema_permissions catalog 
+			 *  If the hook returns false, indicates that object-level and schema-level grants both are present and schema-level grant is revoked.
+			 *  In such case we remove schema-level entry from the bbf_schema_permissions catalog but skip the execution of revoke as object-level grants exist.
+			 */
 			if (update_bbf_schema_permissions_catalog_hook && !(*update_bbf_schema_permissions_catalog_hook) (this_privileges, istmt->is_grant, istmt->grantees,
 				istmt->col_privs, pg_class_tuple->oid, GetUserNameFromId(grantorId, false), 
 				istmt->grant_option, GetUserNameFromId(ownerId, false), istmt->objtype))
@@ -2069,7 +2070,8 @@ ExecGrant_Relation(InternalGrant *istmt)
 				table_close(attRelation, RowExclusiveLock);
 				table_close(relation, RowExclusiveLock);
 				return;
-			}							 
+			}
+										 
 			/*
 			 * Generate new ACL.
 			 */
@@ -2276,7 +2278,6 @@ ExecGrant_common(InternalGrant *istmt, Oid classid, AclMode default_privs,
 			(*bbf_execute_grantstmt_as_dbsecadmin_hook) (get_object_type(classid, objectid), objectid, ownerId, istmt->privileges, &grantorId, &avail_goptions);
 		}
 
-
 		nameDatum = SysCacheGetAttrNotNull(cacheid, tuple,
 										   get_object_attnum_name(classid));
 
@@ -2291,10 +2292,11 @@ ExecGrant_common(InternalGrant *istmt, Oid classid, AclMode default_privs,
 									 NameStr(*DatumGetName(nameDatum)),
 									 0, NULL);
 
-		/* Call the hook to add the permission in bbf_schema_permissions catalog 
-		*  If the hook returns false, indicates that object-level and schema-level grants both are present and schema-level grant is revoked.
-		*  In such case we remove schema-level entry from the bbf_schema_permissions catalog but skip the execution of revoke as object-level grants exist.
-		*/
+		/* 
+		 * Call the hook to add the permission in bbf_schema_permissions catalog 
+		 *  If the hook returns false, indicates that object-level and schema-level grants both are present and schema-level grant is revoked.
+		 *  In such case we remove schema-level entry from the bbf_schema_permissions catalog but skip the execution of revoke as object-level grants exist.
+		 */
 		if (update_bbf_schema_permissions_catalog_hook && !(*update_bbf_schema_permissions_catalog_hook) (this_privileges, istmt->is_grant, istmt->grantees,
 				istmt->col_privs, objectid, GetUserNameFromId(grantorId, false), 
 			istmt->grant_option, GetUserNameFromId(ownerId, false), istmt->objtype))

--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -2061,6 +2061,13 @@ ExecGrant_Relation(InternalGrant *istmt)
 				istmt->col_privs, pg_class_tuple->oid, GetUserNameFromId(grantorId, false), 
 				istmt->grant_option, GetUserNameFromId(ownerId, false), istmt->objtype))
 			{
+				pfree(old_rel_acl);
+				pfree(col_privileges);
+				if (!is_enr)
+					UnlockTuple(relation, &tuple->t_self, InplaceUpdateTupleLock);
+				ReleaseSysCache(tuple);
+				table_close(attRelation, RowExclusiveLock);
+				table_close(relation, RowExclusiveLock);
 				return;
 			}							 
 			/*
@@ -2288,10 +2295,14 @@ ExecGrant_common(InternalGrant *istmt, Oid classid, AclMode default_privs,
 		*  If the hook returns false, indicates that object-level and schema-level grants both are present and schema-level grant is revoked.
 		*  In such case we remove schema-level entry from the bbf_schema_permissions catalog but skip the execution of revoke as object-level grants exist.
 		*/
-		if ((istmt->objtype == OBJECT_PROCEDURE || istmt->objtype == OBJECT_FUNCTION) && update_bbf_schema_permissions_catalog_hook && !(*update_bbf_schema_permissions_catalog_hook) (this_privileges, istmt->is_grant, istmt->grantees,
+		if (update_bbf_schema_permissions_catalog_hook && !(*update_bbf_schema_permissions_catalog_hook) (this_privileges, istmt->is_grant, istmt->grantees,
 				istmt->col_privs, objectid, GetUserNameFromId(grantorId, false), 
 			istmt->grant_option, GetUserNameFromId(ownerId, false), istmt->objtype))
 		{
+			if (!is_enr)
+				UnlockTuple(relation, &tuple->t_self, InplaceUpdateTupleLock);
+			ReleaseSysCache(tuple);
+			table_close(relation, RowExclusiveLock);
 			return;
 		}
 

--- a/src/include/utils/acl.h
+++ b/src/include/utils/acl.h
@@ -312,6 +312,9 @@ extern PGDLLEXPORT pltsql_allow_storing_init_privs_hook_type pltsql_allow_storin
 typedef bool (*bbf_check_member_has_direct_priv_to_grant_role_hook_type) (Oid, Oid);
 extern PGDLLEXPORT bbf_check_member_has_direct_priv_to_grant_role_hook_type bbf_check_member_has_direct_priv_to_grant_role_hook;
 
+typedef bool (*update_bbf_schema_permissions_catalog_hook_type) (AclMode , bool, List*, List*, Oid, const char*, bool, const char*, ObjectType);
+extern PGDLLEXPORT update_bbf_schema_permissions_catalog_hook_type update_bbf_schema_permissions_catalog_hook;
+
 #define IS_BBF_DB_DDLADMIN(namespaceId) \
 	(is_bbf_db_ddladmin_operation_hook &&       \
 	 is_bbf_db_ddladmin_operation_hook(namespaceId))


### PR DESCRIPTION
### Description

The following PR adds grantor information in `sys.babelfish_schema_permissions` catalog, addressing a current limitation in Babelfish. 

The functionality is achieved by hook implementation and reversing the flow of GRANT / REVOKE statement in Babelfish. This enhancement enables users to view grantor of various permissions. 

Another functionality added is the storage of database-level CONNECT permission granted to users. This PR also provides a distinction between the storage of normal permissions and permissions with grant option in `sys.babelfish_schema_permissions` catalog. 

Part of Jira - [BABEL-5690](https://jira.rds.a2z.com/browse/BABEL-5690)

Extension PR : https://github.com/amazon-aurora/babelfish_extensions/pull/73

Signed-off-by: Shreya Rai [shreyaxr@amazon.com](mailto:shreyaxr@amazon.com)